### PR TITLE
feat: Add foundation files for playbook refresh

### DIFF
--- a/.github/workflows/link-check-config.json
+++ b/.github/workflows/link-check-config.json
@@ -1,0 +1,14 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^https://console.aws.amazon.com"
+    },
+    {
+      "pattern": "^https://aws.amazon.com/security-incident-response/"
+    }
+  ],
+  "timeout": "10s",
+  "retryOn429": true,
+  "retryCount": 3,
+  "aliveStatusCodes": [200, 206, 301, 302, 403]
+}

--- a/.github/workflows/validate-playbooks.yml
+++ b/.github/workflows/validate-playbooks.yml
@@ -1,0 +1,34 @@
+name: Validate Playbooks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v19
+        with:
+          globs: |
+            **/*.md
+            !node_modules/**
+
+  link-check:
+    name: Check Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run markdown-link-check
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          config-file: '.github/workflows/link-check-config.json'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD033": false,
+  "MD041": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,61 +1,207 @@
-# Contributing Guidelines
+# Contributing to AWS Incident Response Playbooks
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to this project! We welcome contributions from the community to help improve and expand these incident response playbooks.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+---
 
+## Table of Contents
 
-## Reporting Bugs/Feature Requests
+- [How to Contribute](#how-to-contribute)
+- [Playbook Contributions](#playbook-contributions)
+- [AI Playbook Contributions](#ai-playbook-contributions)
+- [Contribution Guidelines](#contribution-guidelines)
+- [Testing Your Contributions](#testing-your-contributions)
+- [Inclusive Language](#inclusive-language)
+- [Security Issue Notifications](#security-issue-notifications)
+- [Licensing](#licensing)
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+---
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+## How to Contribute
 
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
+1. **Fork** the repository
+2. **Create a branch** for your contribution (`feature/new-playbook-name` or `fix/description`)
+3. **Make your changes** following the guidelines below
+4. **Test your changes** (see Testing section)
+5. **Submit a Pull Request** with a clear description of what you've changed and why
 
+### Types of Contributions We Welcome
 
-## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+- New incident response playbooks for scenarios not yet covered
+- Updates to existing playbooks (new services, updated CLI commands, corrected console paths)
+- AI playbook variants (steering files for Kiro, skills for Claude Code)
+- Automation pattern examples
+- Bug fixes (broken links, typos, formatting)
+- Translations
+- Improvements to documentation and guides
 
-1. You are working against the latest source on the *master* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+---
 
-To send us a pull request, please:
+## Playbook Contributions
 
-1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+### Use the Template
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+All new playbooks **must** follow the standard template: [`PLAYBOOK_TEMPLATE.md`](PLAYBOOK_TEMPLATE.md)
 
+The template ensures consistency across playbooks and includes all required sections:
+- Metadata (scenario, NIST phase mapping, severity indicators)
+- Scope & Assumptions
+- Prerequisites
+- Detection & Analysis
+- Containment
+- Eradication
+- Recovery
+- Post-Incident Activity
+- Automation Hooks
+- Regulatory Considerations
+- References
 
-## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+### Playbook Quality Checklist
 
+Before submitting a playbook, verify:
 
-## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+- [ ] Follows the `PLAYBOOK_TEMPLATE.md` structure
+- [ ] All CLI commands use AWS CLI v2 syntax
+- [ ] Console paths are current (verify in the AWS Console)
+- [ ] All referenced services and features are Generally Available (not preview/beta)
+- [ ] NIST SP 800-61r3 lifecycle phases are correctly mapped
+- [ ] Severity indicators align with the [Triage Guide](TRIAGE_GUIDE.md)
+- [ ] No customer-specific information, account IDs, or PII included
+- [ ] References section includes links to relevant AWS documentation
+- [ ] Regulatory considerations reference the [Regulatory Context](REGULATORY_CONTEXT.md) document
+- [ ] Inclusive language guidelines are followed (see below)
 
+### Updating Existing Playbooks
 
-## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+When updating an existing playbook:
+- Update the "Last Updated" date in the metadata table
+- Note what changed in your PR description
+- If adding new services or features, verify they are GA
+- Ensure the update doesn't break the overall flow of the playbook
 
+---
+
+## AI Playbook Contributions
+
+### Overview
+
+The `ai-playbooks/` directory contains playbooks designed to be consumed by AI-powered IDEs. These come in two formats:
+
+| Format | Location | IDE |
+|---|---|---|
+| Steering files | `ai-playbooks/steering/reference/` | [Kiro](https://kiro.dev/) |
+| Skills | `ai-playbooks/skills/` | [Claude Code](https://code.claude.com/) |
+
+### Creating AI Playbook Variants
+
+When contributing a new AI playbook:
+
+1. **Start with the human playbook** — The AI variant should be derived from an existing human-readable playbook in `playbooks/`
+2. **Use the factory guides:**
+   - For Kiro: Use `ai-playbooks/steering/steering-factory/` as your guide
+   - For Claude Code: Use `ai-playbooks/skills/skill-irp-builder.md` or `skill-irp-playbook-factory.md`
+3. **Update the routing:**
+   - For Kiro: Update keyword patterns in `ai-playbooks/steering/steering-irp-core.md`
+   - For Claude Code: Update routing in `ai-playbooks/skills/CLAUDE.md`
+4. **Test with the IDE** — Verify the AI agent correctly routes to your playbook based on incident description keywords
+
+### AI Playbook Quality Checklist
+
+- [ ] Derived from a corresponding human playbook
+- [ ] Front matter includes correct `inclusion` type (`manual` for incident-specific playbooks)
+- [ ] Keyword patterns are specific enough to avoid false routing
+- [ ] CLI commands are formatted for AI consumption (complete, copy-pasteable)
+- [ ] Decision points are clearly structured for AI reasoning
+- [ ] Both Kiro steering and Claude Code skill versions are provided (preferred, not required)
+
+### AI-Assisted Contributions
+
+We welcome contributions that were drafted with AI assistance. When submitting AI-assisted contributions:
+
+- **Disclose AI usage** — Note in your PR description if AI tools were used in drafting
+- **Verify all technical content** — AI can hallucinate service names, API calls, and console paths. Every command and reference must be human-verified
+- **Test the playbook** — AI-generated playbooks must pass the same testing requirements as human-written ones
+- **Review for coherence** — Ensure the playbook reads naturally and doesn't have repetitive or contradictory sections
+
+---
+
+## Contribution Guidelines
+
+### Writing Style
+
+- Write in clear, direct language appropriate for incident responders under pressure
+- Use active voice ("Revoke the credentials" not "The credentials should be revoked")
+- Be specific about what to look for and what actions to take
+- Include both CLI commands and console path references where applicable
+- Use American English spelling (behavior, color, analyze, organization, authorize) for consistency across the repository
+
+### Formatting
+
+- Use Markdown formatting consistently
+- Code blocks must specify the language (```bash, ```json, etc.)
+- Tables should be used for structured data (findings, services, parameters)
+- Use blockquotes (>) for important warnings or notes
+- Internal links should use relative paths
+
+### Scope
+
+- Playbooks should focus on **AWS-specific** incident response
+- Keep content within the shared responsibility model — we cover security **in** the cloud
+- Do not include proprietary tooling or vendor-specific solutions (beyond AWS services)
+- Reference external tools generically (e.g., "your SIEM" not "Splunk")
+
+---
+
+## Testing Your Contributions
+
+### Minimum Testing Requirements
+
+1. **Link validation** — All internal and external links resolve correctly
+2. **CLI command verification** — Run commands against a test account to verify syntax and output
+3. **Console path verification** — Navigate the referenced console paths to confirm they exist
+4. **Markdown rendering** — Preview your markdown to ensure tables, code blocks, and formatting render correctly
+
+### Recommended Testing
+
+4. **Scenario walkthrough** — Walk through the playbook steps in a test/sandbox AWS account
+5. **Peer review** — Have someone unfamiliar with the scenario follow the playbook
+6. **AI playbook testing** — For AI variants, test that the IDE correctly routes to and executes the playbook
+
+### Testing Tools
+
+- [markdownlint](https://github.com/DavidAnson/markdownlint) — Markdown style and consistency
+- [markdown-link-check](https://github.com/tcort/markdown-link-check) — Verify all links resolve
+- AWS CLI with `--dry-run` flags where available
+- A dedicated AWS test account (never test against production)
+
+---
+
+## Inclusive Language
+
+All contributions must use inclusive language. The following terms should be avoided:
+
+| Don't Use | Use Instead |
+|---|---|
+| master | primary, main, leader, controller |
+| slave | replica, secondary, follower, responder |
+| whitelist | allowlist, approved list, inclusion list |
+| blacklist | denylist, blocklist, exclusion list |
+| whiteday(s) | clear day(s), allowed day(s) |
+| blackday(s) | blocked day(s) |
+
+---
+
+## Security Issue Notifications
+
+If you discover a potential security issue in this project, please notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [aws-security@amazon.com](mailto:aws-security@amazon.com).
+
+**Please do not create a public GitHub issue for security vulnerabilities.**
+
+---
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](LICENSE) file for details. By contributing, you agree that your contributions will be licensed under the same terms.
 
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+- Documentation: Creative Commons Attribution-ShareAlike 4.0 International License
+- Sample code: MIT-0 License

--- a/PLAYBOOK_TEMPLATE.md
+++ b/PLAYBOOK_TEMPLATE.md
@@ -1,0 +1,452 @@
+<!--
+  CONTRIBUTOR NOTE:
+  - Delete all italicized placeholder text when filling in this template.
+  - Sections marked "if applicable" can be removed entirely if not relevant to your scenario.
+  - Refer to CONTRIBUTING.md for quality checklist and submission guidelines.
+  - Use P1–P4 severity nomenclature consistently (see Severity Classification section).
+-->
+
+# IRP-[INCIDENT-TYPE]: [Incident Type Display Name]
+
+> **Playbook Version:** 1.0
+> **Last Reviewed:** YYYY-MM-DD
+> **Status:** `Draft` | `Active` | `Deprecated`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-CredCompromise](../IRP-CredCompromise.md) | [IRP-Ransomware](../IRP-Ransomware.md) | *(add as applicable)*
+
+---
+
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
+
+---
+
+## Overview
+
+**One-paragraph summary of this incident type:** What it is, how it typically manifests in AWS environments, and why it matters. Keep this to 3–5 sentences — just enough context for a responder who may be new to this scenario.
+
+### Out of Scope
+
+This playbook does **not** cover:
+
+- *(e.g., "If you are seeing AssumeRole chain abuse without initial credential theft, see [IRP-STSTokenAbuse](../IRP-STSTokenAbuse.md) instead.")*
+- *(e.g., "For ransomware that originated from this compromise type, pivot to [IRP-Ransomware](../IRP-Ransomware.md) once containment here is complete.")*
+- *(List 2–4 adjacent scenarios and where to route them)*
+
+### Applicable Finding Types
+
+List the detection signals that should route a responder to this playbook.
+
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon GuardDuty | `GuardDuty:FindingType/Example` | HIGH |
+| AWS Security Hub | `Control ID / Finding Title` | CRITICAL |
+| CloudTrail | `eventName: ExampleAPI` | — |
+| Custom / Third-Party | *(describe)* | — |
+
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
+
+### Severity Classification
+
+Use this table to determine incident priority at time of detection. Escalate immediately if P1 criteria are met.
+
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | *(e.g., active data exfiltration confirmed, production account fully compromised)* |
+| **P2 — High** | *(e.g., suspicious activity confirmed but blast radius unclear)* |
+| **P3 — Medium** | *(e.g., anomalous behavior detected, no confirmed impact yet)* |
+| **P4 — Low** | *(e.g., policy violation with no active threat, informational finding)* |
+
+---
+
+## Part 1 — Prepare
+
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
+
+### 1.1 Required AWS Service Configurations
+
+Confirm the following are enabled and configured in all applicable accounts and regions before an incident occurs.
+
+- [ ] Amazon GuardDuty enabled with findings exported to Security Hub
+- [ ] AWS CloudTrail enabled with multi-region trail logging to S3 with integrity validation
+- [ ] AWS Config enabled with delivery channel configured
+- [ ] VPC Flow Logs enabled for all relevant VPCs
+- [ ] S3 access logging enabled on sensitive buckets
+- [ ] Amazon Detective enabled (for graph-based investigation)
+- [ ] *(Add scenario-specific requirements here)*
+
+> 🤖 **Automation opportunity:** Use AWS Config conformance packs or Security Hub standards to continuously validate these prerequisites. [Link TBD]
+
+### 1.2 IAM & Access Prerequisites
+
+Ensure the following access is pre-provisioned and tested — *do not provision break-glass access during an active incident*.
+
+- [ ] Break-glass IAM role with least-privilege IR permissions exists and is documented
+- [ ] IR team members can assume the break-glass role with MFA
+- [ ] Access to AWS Security Incident Response console (if subscribed) is confirmed
+- [ ] Forensic account (isolated) is available for evidence preservation
+- [ ] *(Add scenario-specific IAM requirements)*
+
+### 1.3 Communication & Escalation
+
+> 📋 Do not include names. Use roles only. Maintain a separate, access-controlled contact list.
+
+| Role | Responsibility |
+|---|---|
+| IR Lead | Overall incident coordination, status updates |
+| Account Owner | Business context, authorization for containment actions |
+| Legal / Compliance | Regulatory notification obligations, evidence hold |
+| Communications | Internal and external messaging |
+| AWS CIRT | Engage via AWS Support case or Security Incident Response service (P1/P2, if available) |
+| *(Add role)* | *(Add responsibility)* |
+
+**Escalation path:**
+Detection → IR Lead notified → Severity assessed → P1/P2: AWS CIRT engaged, Legal notified → P3/P4: IR Lead manages internally
+
+### 1.4 Game Day Guidance
+
+This playbook should be exercised before it is needed. Recommended testing cadence: **annually at minimum, semi-annually for P1 scenarios.**
+
+Suggested tabletop scenario for this incident type:
+> *[Describe a 2–3 sentence scenario prompt that an exercise facilitator can use to kick off a tabletop for this specific incident type.]*
+
+Reference: [AWS Security Incident Response Game Days](https://docs.aws.amazon.com/security-ir/latest/userguide/game-days.html)
+
+---
+
+## Part 2 — Detect & Analyze
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyze)
+> **Goal:** Confirm whether an incident has occurred, scope its impact, and gather evidence for containment and investigation.
+
+### 2.1 Initial Triage Questions
+
+Answer these quickly to determine scope and priority. Each question should take < 2 minutes to answer.
+
+- [ ] Is this a confirmed incident or an anomalous finding requiring investigation?
+- [ ] Which AWS accounts and regions are potentially affected?
+- [ ] Are production workloads or sensitive data involved?
+- [ ] Is the threat actor potentially still active in the environment?
+- [ ] Has any data left the AWS environment (exfiltration)?
+- [ ] Are there downstream customers, partners, or regulatory implications?
+- [ ] *(Add scenario-specific triage questions)*
+
+**If 3 or more questions are answered YES → escalate to P1 immediately.**
+
+### 2.2 Evidence Collection Checklist
+
+Collect and preserve the following **before taking any containment actions**. Evidence collected after containment may be incomplete or altered.
+
+> ⚠️ **Do not terminate instances or delete resources before snapshotting and preserving evidence.**
+
+| Evidence Type | How to Collect | Where to Store |
+|---|---|---|
+| CloudTrail logs (relevant time window) | AWS Console / Athena query / CLI | Forensic S3 bucket |
+| GuardDuty finding JSON | GuardDuty console → Export | Forensic S3 bucket |
+| VPC Flow Logs | CloudWatch Logs / S3 | Forensic S3 bucket |
+| EC2 instance memory / disk snapshot | *(if applicable)* | Forensic account |
+| IAM credential last-used data | `aws iam get-credential-report` | IR ticket / notes |
+| *(Add scenario-specific evidence)* | | |
+
+**Useful CloudTrail / Athena queries for this scenario:**
+
+```sql
+-- Example: Find all API calls from a suspected IAM principal in a time window
+SELECT eventTime, eventName, sourceIPAddress, userAgent, errorCode
+FROM cloudtrail_logs
+WHERE userIdentity.arn LIKE '%SUSPECTED_PRINCIPAL%'
+  AND eventTime BETWEEN '2024-01-01T00:00:00Z' AND '2024-01-02T00:00:00Z'
+ORDER BY eventTime ASC;
+```
+
+> *(Add 2–3 queries specific to this incident type. Contributors: the generic queries in Appendix A are starting points — the real value is scenario-specific queries. See [CloudTrail query examples](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html).)*
+
+### 2.3 Severity Determination
+
+Based on triage and initial evidence, assign a priority using the criteria in [Severity Classification](#severity-classification).
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Active threat actor in environment | P1 |
+| Confirmed data impact, actor no longer active | P2 |
+| Suspicious activity, scope unclear | P3 |
+| Policy violation, no active threat | P4 |
+
+### 2.4 Getting Help from AWS
+
+For P1 or P2 incidents, consider engaging AWS for additional support:
+
+- **AWS Security Incident Response service** (if enabled): Open a case via the [Security Incident Response console](https://console.aws.amazon.com/security-ir/), attach relevant findings, and grant AWS CIRT access to the affected account(s).
+- **AWS Support** (any AWS Support plan): Open a support case with severity "Critical" or "Urgent" and request assistance from the AWS Customer Incident Response Team (CIRT).
+- **AWS Trust & Safety** (for abuse reports): If the incident involves resources being used to attack others, report via the [AWS abuse form](https://support.aws.amazon.com/#/contacts/report-abuse).
+
+> 📌 You do not need the AWS Security Incident Response service to get help. All AWS customers can request CIRT assistance through a support case, regardless of support plan level. The Security Incident Response service provides additional automation, case management, and proactive triage capabilities.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Stop the spread of the incident and prevent further damage without destroying evidence.
+
+### 3.1 Containment Decision
+
+Before acting, consider the tradeoff:
+
+```
+Is containment action required immediately?
+│
+├── YES (active exfiltration / lateral movement)
+│     └── Proceed to 3.2 — accept potential service disruption
+│
+└── NO (threat appears inactive)
+      └── Consult Account Owner and IR Lead before proceeding
+            Can we contain without service disruption?
+            ├── YES → Proceed to 3.2
+            └── NO  → Document business impact, obtain authorization, then proceed
+```
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates. `[Account Owner]` authorizes actions that may cause service disruption.
+
+**Step-by-step containment for this incident type:**
+
+1. **Step title**
+   Description of the action. Be specific — include CLI commands or console navigation path where possible.
+   ```bash
+   # Example CLI command
+   aws iam delete-access-key --access-key-id AKIAIOSFODNN7EXAMPLE --user-name compromised-user
+   ```
+
+2. **Step title**
+   *(Repeat as needed)*
+
+3. **Isolate affected resource(s)**
+   *(Describe isolation approach specific to this incident — e.g., security group modification, IAM policy deny, network ACL)*
+   ```bash
+   # Example: Attach restrictive security group to isolate EC2 instance
+   aws ec2 modify-instance-attribute \
+     --instance-id i-1234567890abcdef0 \
+     --groups sg-forensic-isolation
+   ```
+
+> 🤖 **Automation opportunity:** AWS Systems Manager Automation runbook for [describe action]. [Link TBD]
+
+### 3.3 Evidence Preservation Reminders
+
+After containment begins, ensure the following before modifying or terminating any resources:
+
+- [ ] EBS snapshots taken for all affected EC2 instances
+- [ ] Memory capture completed (if required for this incident type)
+- [ ] All relevant logs exported to forensic S3 bucket
+- [ ] S3 Object Lock or legal hold applied to forensic bucket
+- [ ] CloudTrail integrity validation confirmed on exported logs
+
+---
+
+## Part 4 — Eradicate & Recover
+
+> **CSF 2.0 Function:** Respond (Eradicate) · Recover
+> **Goal:** Remove the root cause, validate the environment is clean, and restore normal operations.
+
+### 4.1 Root Cause Identification
+
+> `[IR Lead]` owns this step. Document findings in the IR ticket in real time.
+
+Determine the root cause before beginning eradication. Common root causes for this incident type:
+
+- *(List 3–5 common root causes specific to this scenario)*
+- *(e.g., for CredCompromise: hardcoded credentials in public repo, phishing, overly permissive IAM policy)*
+
+Use evidence collected in Part 2 to trace the initial access vector and full attack path.
+
+### 4.2 Eradication Actions
+
+> `[IR Lead]` coordinates. `[Account Owner]` approves changes to production resources.
+
+1. **Step title**
+   *(Specific remediation action)*
+
+2. **Step title**
+   *(Repeat as needed)*
+
+3. **Remove attacker persistence mechanisms**
+   Check for and remove:
+   - [ ] Unauthorized IAM users, roles, or access keys created during incident
+   - [ ] Unauthorized Lambda functions, EC2 instances, or other resources
+   - [ ] Modified SCPs, resource policies, or trust relationships
+   - [ ] Backdoors in application code or configuration
+   - [ ] *(Add scenario-specific persistence mechanisms)*
+
+> 🤖 **Automation opportunity:** AWS Config auto-remediation rules can detect and revert some configuration changes automatically. [Link TBD]
+
+### 4.3 Recovery Actions
+
+1. **Restore from known-good state**
+   *(Describe restore procedure — AMI, backup, IaC re-deployment, etc.)*
+
+2. **Re-enable services and access**
+   - [ ] Restore IAM access for legitimate principals (with new credentials)
+   - [ ] Re-enable any services suspended during containment
+   - [ ] Validate application functionality
+
+3. **Harden against recurrence**
+   - [ ] *(Specific hardening action for this incident type)*
+   - [ ] *(e.g., enable MFA enforcement, rotate all credentials, restrict public access)*
+
+### 4.4 Recovery Validation
+
+Confirm the environment is clean before declaring the incident resolved.
+
+- [ ] No unauthorized resources remain in affected accounts
+- [ ] All credentials created or used by attacker have been revoked
+- [ ] GuardDuty / Security Hub show no active findings related to this incident
+- [ ] Application and service health metrics are within normal range
+- [ ] Monitoring and alerting confirmed operational
+- [ ] AWS Security Incident Response case updated / closed (if applicable)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Learn from this incident to reduce the likelihood and impact of future occurrences.
+
+### 5.1 Timeline Reconstruction
+
+Document the full incident timeline. Complete this within 24–48 hours while memory is fresh.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| YYYY-MM-DD HH:MM | *(e.g., Initial compromise occurred)* | CloudTrail log | Threat actor |
+| YYYY-MM-DD HH:MM | *(e.g., GuardDuty finding generated)* | GuardDuty | AWS |
+| YYYY-MM-DD HH:MM | *(e.g., IR team notified)* | On-call alert | IR Lead |
+| YYYY-MM-DD HH:MM | *(e.g., Containment completed)* | IR ticket | IR Lead |
+| YYYY-MM-DD HH:MM | *(e.g., Recovery validated)* | IR ticket | IR Lead |
+
+**Key metrics to capture:**
+
+| Metric | Value |
+|---|---|
+| Time to Detect (TTD) | *HH:MM from initial event to detection* |
+| Time to Notify (TTN) | *HH:MM from detection to IR team notified* |
+| Time to Contain (TTC) | *HH:MM from notification to containment* |
+| Time to Recover (TTR) | *HH:MM from containment to recovery validated* |
+| Total Incident Duration | *HH:MM* |
+| Affected Resources | *Count and type* |
+| Data Impact | *Confirmed / Suspected / None* |
+
+### 5.2 Post-Incident Review
+
+Conduct a blameless post-incident review within **5 business days** for P1/P2, **15 business days** for P3/P4.
+
+Discussion questions:
+
+1. What was the initial access vector? Could it have been prevented with existing controls?
+2. How was the incident detected? Was detection fast enough?
+3. Were the right people notified at the right time?
+4. Did containment actions work as expected? Were there unintended side effects?
+5. Were there any gaps in runbooks, automation, or tooling that slowed response?
+6. What would have reduced the blast radius?
+7. What single change would most improve our response to this scenario in future?
+
+### 5.3 Detection Gap Analysis
+
+For each detection source that *did not* catch this incident early, document why and what would have:
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., GuardDuty finding suppressed)* | *(Suppression rule too broad)* | *(Narrow suppression rule)* | | |
+| *(e.g., No alert on root API usage)* | *(CloudWatch alarm not configured)* | *(Create alarm for root API calls)* | | |
+
+### 5.4 Playbook Update Checklist
+
+Review and update this playbook based on what you learned. Do not wait for the next scheduled review.
+
+- [ ] Were triage questions sufficient? Add/remove as needed.
+- [ ] Were evidence collection steps accurate for this scenario?
+- [ ] Were containment actions effective? Update steps if not.
+- [ ] Were any automation opportunities identified? Add stubs to relevant sections.
+- [ ] Were severity criteria accurate? Adjust if incidents were under- or over-classified.
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+---
+
+## Appendix A — Useful Queries
+
+### CloudTrail (Athena)
+
+```sql
+-- Template query: All API activity in a time window for a specific principal
+SELECT eventTime, eventName, awsRegion, sourceIPAddress, userAgent,
+       errorCode, errorMessage
+FROM cloudtrail_logs
+WHERE userIdentity.arn = 'arn:aws:iam::123456789012:user/SUSPECTED_USER'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+```
+
+```sql
+-- Template query: High-volume API calls (potential enumeration or exfiltration)
+SELECT eventName, COUNT(*) as call_count, sourceIPAddress
+FROM cloudtrail_logs
+WHERE eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY eventName, sourceIPAddress
+HAVING call_count > 100
+ORDER BY call_count DESC;
+```
+
+> **Contributors:** The generic queries above are starting points. The real value is scenario-specific queries — e.g., "find all AssumeRole calls that crossed account boundaries" for the STS playbook, or "identify S3 GetObject calls exceeding normal volume" for data exfiltration. Please add 2–3 queries tailored to this incident type.
+
+### GuardDuty Finding Export (CLI)
+
+```bash
+# List findings for a detector filtered by severity
+aws guardduty list-findings \
+  --detector-id DETECTOR_ID \
+  --finding-criteria '{"Criterion":{"severity":{"Gte":7}}}' \
+  --region us-east-1
+
+# Get full finding details
+aws guardduty get-findings \
+  --detector-id DETECTOR_ID \
+  --finding-ids FINDING_ID_1 FINDING_ID_2
+```
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal / Compliance]` owns this section during an active incident.
+
+See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obligation matrix by regulation and incident type.
+
+**Quick reference for this scenario:**
+
+| Regulation | Trigger Condition | Timeframe |
+|---|---|---|
+| *(e.g., GDPR Art. 33)* | *(e.g., Personal data confirmed accessed)* | *(e.g., 72 hours to supervisory authority)* |
+| *(Add only rows relevant to this specific incident type)* | | |
+
+> ⚠️ The clock starts at **awareness**, not confirmation. When in doubt, assume notification is required and consult Legal immediately.
+
+---
+
+## Appendix C — Reference Links
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+- [AWS Security Incident Response Service Documentation](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Well-Architected Framework — Security Pillar: Incident Response](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/incident-response.html)
+- [Amazon GuardDuty Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
+- [AWS CloudTrail Query Examples (Athena)](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html)
+- *(Add scenario-specific references)*
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | YYYY-MM-DD | *(Author / team)* | Initial draft |

--- a/README.md
+++ b/README.md
@@ -1,31 +1,128 @@
-## AWS Incident Response Playbook Samples
+# AWS Incident Response Playbook Samples
 
-These playbooks and ai-playbooks are created to be used as templates only. They should be customized by administrators working with AWS to suit their particular needs, risks, available tools and work processes. These guides are not official AWS documentation and are provided as-is to customers using AWS products and who are looking to improve their incident response capability.
+These playbooks are provided as templates for organizations building incident response capability on AWS. They should be customized to suit your specific needs, risks, available tools, and work processes. These guides are not official AWS documentation and are provided as-is.
 
-The playbooks and ai-playbooks included cover several common scenarios faced by AWS customers. They outline steps based on the [NIST Computer Security Incident Handling Guide](https://csrc.nist.gov/pubs/sp/800/61/r3/final) (Special Publication 800-61 Revision 3) that can be used to:
+All playbooks are aligned to the [NIST SP 800-61 Revision 3: Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final) framework and mapped to the CSF 2.0 Community Profile.
 
-* Gather evidence
-* Contain and then eradicate the incident
-* Recover from the incident
-* Conduct post-incident activities, including post-mortem and feedback processes
+> **What's new in this version:** This repository was significantly refreshed in 2026. Playbooks have been rewritten to align with NIST SP 800-61r3 (previously r2), reference current AWS services (including the AWS Security Incident Response service, IAM Access Analyzer, Amazon Macie, and GuardDuty Runtime Monitoring), and follow a standardized template structure. AI-assisted playbook variants and automation patterns have been added.
 
-The playbooks are markdown files designed to be used by humans as guidance when responding to an incident in their AWS environments. The ai-playbooks are designed to be consumed by an integrated development environment "IDE" leveraging a large language model "LLM" as "steering files" or "skills" (depending on your chosen IDE and LLM). Additional information for these files (including usage) are in the [README](aws-incident-response-playbooks/blob/main/ai-playbooks/README.md) in that directory.
+---
 
-Interested readers may also find the AWS Security Incident Response Guide (first published in June 2019) a useful guide as an overview of how the below steps were created.
+## Getting Started
 
-Each playbook corresponds to a unique incident and there are 5 parts to handling each incident type, following the NIST guidelines referenced above. Each part corresponds to an action in that NIST document.
+| Resource | Purpose |
+|---|---|
+| [Triage Guide](TRIAGE_GUIDE.md) | Quickly assess incident severity (P1–P4) and determine response urgency |
+| [Playbook Template](PLAYBOOK_TEMPLATE.md) | Standard structure for all playbooks — use when creating new ones |
+| [Regulatory Context](REGULATORY_CONTEXT.md) | Notification obligations by incident type and regulation |
+| [Contributing](CONTRIBUTING.md) | How to contribute new playbooks or improvements |
 
-It is not sufficient to customize these scenarios to the need of your customers, organization or applications. It is important that these playbook scenarios are tested (for example, in Game Days) prior to deployment to your knowledge management system and that all responders are familiar with the actions required to respond to an incident.
+---
 
-Note that some of the incident response steps noted in each scenario may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing these scenarios and testing them will help you to determine if additional costs will be incurred. You can use AWS Cost Explorer and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be. Note also that if you have a subscription with an IDE or LLM, using the AI playbooks will also use tokens, contributing to whatever your token usage limitations are based on the plan(s) you have.
+## Playbooks
+
+### Identity & Access Scenarios
+
+| Playbook | Description |
+|---|---|
+| [Credential Compromise](playbooks/IRP-CredCompromise.md) | IAM access key or console credential theft and abuse |
+| [STS Token Abuse](playbooks/IRP-STSTokenAbuse.md) | AssumeRole chain attacks, cross-account pivoting, IMDS credential theft |
+| [Identity Center Compromise](playbooks/IRP-IdentityCenterCompromise.md) | AWS SSO permission set abuse, identity store manipulation |
+| [Federated Access Abuse](playbooks/IRP-FederatedAccessAbuse.md) | BEC or IdP compromise (Okta, Azure AD) leading to AWS access |
+| [Insider Threat](playbooks/IRP-InsiderThreat.md) | Anomalous authorized user behavior — technical detection and containment |
+
+### Compute & Infrastructure Scenarios
+
+| Playbook | Description |
+|---|---|
+| [EC2 Compromise](playbooks/IRP-EC2Compromise.md) | Instance-level compromise — C2, lateral movement, IMDS abuse |
+| [Container/EKS Compromise](playbooks/IRP-ContainerEKSCompromise.md) | Pod escape, malicious images, IRSA abuse, Kubernetes RBAC manipulation |
+| [CI/CD Compromise](playbooks/IRP-CICDCompromise.md) | Pipeline compromise, dependency poisoning, build artifact tampering |
+| [Cryptomining](playbooks/IRP-Cryptomining.md) | Unauthorized compute resource abuse for cryptocurrency mining |
+| [Ransomware](playbooks/IRP-Ransomware.md) | Cloud-native ransomware — EBS encryption, S3 deletion, KMS abuse |
+| [Denial of Service](playbooks/IRP-DoS.md) | DDoS and application-layer attacks |
+
+### Data & Application Scenarios
+
+| Playbook | Description |
+|---|---|
+| [Data Access](playbooks/IRP-DataAccess.md) | Unauthorized access to data stores (S3, DynamoDB, Secrets Manager) |
+| [S3 Data Exfiltration](playbooks/IRP-S3DataExfiltration.md) | Bulk S3 extraction — replication abuse, presigned URLs, batch operations |
+| [Root Account Takeover](playbooks/IRP-AccountTakeoverRoot.md) | Root credential compromise — always P1 |
+| [Personal Data Breach](playbooks/IRP-PersonalDataBreach.md) | Regulatory notification workflow when personal data is involved |
+
+### GuardDuty Finding Quick-Response Guides
+
+These are finding-specific quick-response guides (5-minute triage) that route to the full lifecycle playbooks above.
+
+| Category | Findings Covered |
+|---|---|
+| [EC2 Findings](guardduty-playbooks/ec2-findings.md) | Backdoor, Trojan, CryptoCurrency, UnauthorizedAccess, Recon, Impact |
+| [S3 Findings](guardduty-playbooks/s3-findings.md) | Exfiltration, Discovery, Impact, Policy, UnauthorizedAccess |
+| [IAM Findings](guardduty-playbooks/iam-findings.md) | CredentialAccess, Discovery, InitialAccess, Persistence, PrivilegeEscalation |
+| [EKS & Runtime Findings](guardduty-playbooks/eks-runtime-findings.md) | Execution, PrivilegeEscalation, Persistence, Discovery, DefenseEvasion |
+
+---
+
+## AI-Assisted Playbooks
+
+The `ai-playbooks/` directory contains vendor-agnostic, AI-readable versions of these playbooks. They work with any AI coding assistant or LLM — Kiro, Claude Code, Cursor, Windsurf, GitHub Copilot, or any tool that can consume markdown as context.
+
+The AI playbooks are designed with human-in-the-loop safeguards: the AI guides and recommends, but always waits for explicit human confirmation before executing any action that modifies the environment.
+
+See the [AI Playbooks README](ai-playbooks/README.md) for setup instructions and architecture details.
+
+---
+
+## Automation Patterns
+
+The `automation-patterns/` directory contains reference examples showing how to wire AWS services for IR automation. These are starting points, not production-ready IaC.
+
+| Pattern | Description |
+|---|---|
+| [EventBridge Rules](automation-patterns/eventbridge-rules.md) | 10 event patterns for common IR triggers (GuardDuty, root activity, CloudTrail tampering) |
+| [Step Functions Workflow](automation-patterns/step-functions-ir-workflow.md) | Reference state machine for IR orchestration with human approval gates |
+| [Security Hub Custom Actions](automation-patterns/security-hub-custom-actions.md) | Human-in-the-loop automation — click a button to isolate, revoke, or preserve |
+
+For production-ready implementations, see [aws-samples/aws-security-incident-response-integrations](https://github.com/aws-samples/aws-security-incident-response-integrations).
+
+---
+
+## Getting Help from AWS
+
+All AWS customers can request assistance from the AWS Customer Incident Response Team (CIRT) through a support case, regardless of support plan level. You do not need any specific service subscription to get help during a security incident.
+
+Additionally, the [AWS Security Incident Response](https://aws.amazon.com/security-incident-response/) service provides automated triage, case management, and proactive engagement capabilities for customers who enable it.
+
+---
+
+## Related Resources
+
+| Resource | Description |
+|---|---|
+| [AWS Security Incident Response Guide (2023)](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) | Comprehensive guide to IR on AWS |
+| [NIST SP 800-61r3](https://csrc.nist.gov/pubs/sp/800/61/r3/final) | Incident Response Recommendations and Considerations |
+| [AWS Customer Playbook Framework](https://github.com/aws-samples/aws-customer-playbook-framework) | Additional playbook templates with multi-language support |
+| [AWS Security IR Integrations](https://github.com/aws-samples/sample-aws-security-incident-response-integrations) | Sample automation integrations for IR workflows |
+| [AWS CIRT Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/) | Hands-on IR workshops |
+| [AWS Threat Detection & Response Workshop](https://catalog.workshops.aws/threat-detection-and-response) | Workshop for detection and response |
+| [AWS Security Reference Architecture](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html) | Prescriptive security architecture guidance |
+
+---
 
 ## Usage
 
-The playbooks are written in markdown to facilitate editing and consumption into a variety of user systems.
+These playbooks are written in markdown to facilitate editing and consumption into a variety of systems. They should be tested (for example, in Game Days) prior to deployment and all responders should be familiar with the actions required.
+
+Some incident response steps may incur costs in your AWS account(s). Customizing and testing these scenarios will help you determine potential cost impact.
+
+---
 
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+---
 
 ## License Summary
 

--- a/REGULATORY_CONTEXT.md
+++ b/REGULATORY_CONTEXT.md
@@ -1,0 +1,97 @@
+# Regulatory Context for Incident Response
+
+This document provides a lightweight reference mapping incident types to regulatory notification obligations. It is **not legal advice** — organizations must consult their legal counsel to determine specific obligations based on jurisdiction, data types, and contractual requirements.
+
+---
+
+## Purpose
+
+During an active incident, responders need to quickly understand whether regulatory notification timelines are triggered. This document helps answer: "Do we need to notify someone, and how fast?"
+
+---
+
+## Notification Obligation Matrix
+
+| Regulation | Jurisdiction | Trigger Condition | Notification Timeline | Who to Notify |
+|---|---|---|---|---|
+| **GDPR Art. 33** | EU/EEA | Personal data breach (access, destruction, loss, alteration, unauthorized disclosure) | 72 hours to supervisory authority | Data Protection Authority (DPA) of lead establishment |
+| **GDPR Art. 34** | EU/EEA | High risk to rights and freedoms of individuals | Without undue delay to affected individuals | Data subjects directly |
+| **CCPA/CPRA** | California, US | Unauthorized access to unencrypted personal information | "Most expedient time possible" (no fixed hours) | California AG + affected individuals |
+| **HIPAA Breach Notification** | US (healthcare) | Unsecured protected health information (PHI) accessed | 60 days to HHS; without unreasonable delay to individuals | HHS, affected individuals, media (if >500 individuals) |
+| **PCI-DSS 12.10** | Global (card data) | Compromise of cardholder data environment | Immediately to payment brands; varies by brand | Acquiring bank, payment card brands (Visa, Mastercard, etc.) |
+| **PIPEDA** | Canada | Breach of security safeguards involving personal information, real risk of significant harm | "As soon as feasible" to OPC; as soon as feasible to individuals | Office of the Privacy Commissioner (OPC) + affected individuals |
+| **Australian Privacy Act (NDB)** | Australia | Eligible data breach (unauthorized access/disclosure of personal information, likely serious harm) | "As soon as practicable" after assessment (30-day assessment window) | Office of the Australian Information Commissioner (OAIC) + affected individuals |
+| **UK GDPR / DPA 2018** | United Kingdom | Personal data breach | 72 hours to ICO | Information Commissioner's Office (ICO) |
+| **DORA (EU)** | EU (financial) | Major ICT-related incident | Initial notification within 4 hours of classification; intermediate within 72 hours; final within 1 month | Competent authority (national financial regulator) |
+| **NIS2 Directive** | EU | Significant incident affecting essential/important entities | Early warning within 24 hours; incident notification within 72 hours; final report within 1 month | National CSIRT or competent authority |
+| **SEC Cybersecurity Rules** | US (public companies) | Material cybersecurity incident | 4 business days after materiality determination | SEC (Form 8-K) |
+| **SOC 2 (CC7.3/CC7.4)** | Global (service orgs) | Security incident affecting trust services criteria | Per contractual obligations with customers | Affected customers per agreement |
+
+---
+
+## Incident Type → Regulatory Trigger Mapping
+
+| Incident Type | Likely Regulatory Triggers | Key Question |
+|---|---|---|
+| **Credential Compromise** | GDPR, CCPA, PIPEDA, NDB (if personal data accessed) | Was personal data accessible with the compromised credentials? |
+| **Data Exfiltration (S3)** | GDPR, CCPA, HIPAA, PCI-DSS, PIPEDA, NDB, SEC | What data types were in the affected buckets? |
+| **Ransomware** | GDPR (data unavailability = breach), HIPAA, NIS2, DORA | Was personal/health/financial data encrypted or exfiltrated? |
+| **DDoS** | NIS2, DORA (if essential service), SOC 2 | Did the outage affect availability of regulated services? |
+| **Insider Threat** | GDPR, CCPA, HIPAA (depending on data accessed) | What data did the insider access beyond their authorization? |
+| **Root Account Takeover** | All applicable regulations (assume worst case) | Treat as full-scope breach until proven otherwise |
+| **Cryptomining** | Generally NOT a notification trigger | Unless the attacker also accessed data (check lateral movement) |
+| **CI/CD Compromise** | PCI-DSS (if cardholder environment), SOC 2 | Could the supply chain compromise have affected production data? |
+
+---
+
+## Key Principles
+
+### 1. When in Doubt, Assume Notification is Required
+It is better to notify early and update later than to miss a deadline. Most regulations allow for incomplete initial notifications with follow-up reports.
+
+### 2. The Clock Starts at Awareness, Not Confirmation
+For GDPR and most frameworks, the notification clock starts when you become **aware** of the breach — not when you've completed your investigation. "Awareness" typically means when you have a reasonable degree of certainty that a breach has occurred.
+
+### 3. Document Everything
+Regardless of whether notification is required, document:
+- When the incident was detected
+- When the incident was assessed
+- The rationale for notification/non-notification decisions
+- All communications with regulators and affected parties
+
+### 4. Containment Does Not Eliminate Notification Obligations
+Even if you contain an incident quickly, if personal data was accessed (even briefly), notification obligations may still apply.
+
+---
+
+## AWS-Specific Considerations
+
+### Shared Responsibility
+- AWS is responsible for security **of** the cloud (infrastructure)
+- Customers are responsible for security **in** the cloud (their data, configurations, access)
+- Regulatory notification for customer data breaches is the **customer's** responsibility
+- AWS will notify customers if AWS infrastructure is compromised (per the [AWS Shared Responsibility Model](https://aws.amazon.com/compliance/shared-responsibility-model/))
+
+### AWS Artifact
+Use [AWS Artifact](https://aws.amazon.com/artifact/) to access AWS compliance reports (SOC 2, PCI-DSS, ISO 27001) that may be needed for your regulatory response.
+
+### AWS Security Incident Response Service
+The [AWS Security Incident Response](https://aws.amazon.com/security-incident-response/) service can assist with evidence gathering and documentation that supports regulatory notification requirements.
+
+---
+
+## References
+
+- [GDPR Full Text](https://gdpr-info.eu/)
+- [CCPA/CPRA Text](https://oag.ca.gov/privacy/ccpa)
+- [HIPAA Breach Notification Rule](https://www.hhs.gov/hipaa/for-professionals/breach-notification/index.html)
+- [PCI-DSS v4.0](https://www.pcisecuritystandards.org/)
+- [PIPEDA Breach Reporting](https://www.priv.gc.ca/en/privacy-topics/business-privacy/safeguards-and-breaches/privacy-breaches/respond-to-a-privacy-breach-at-your-business/)
+- [Australian NDB Scheme](https://www.oaic.gov.au/privacy/notifiable-data-breaches)
+- [NIS2 Directive](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive)
+- [SEC Cybersecurity Disclosure Rules](https://www.sec.gov/rules/final/2023/33-11216.pdf)
+- [DORA Regulation](https://www.digital-operational-resilience-act.com/)
+
+---
+
+> **Disclaimer:** This document is provided for informational purposes only and does not constitute legal advice. Regulatory requirements vary by jurisdiction, industry, data type, and contractual obligations. Always consult qualified legal counsel for specific notification decisions.

--- a/TRIAGE_GUIDE.md
+++ b/TRIAGE_GUIDE.md
@@ -1,0 +1,140 @@
+# Incident Triage Guide
+
+This guide helps responders quickly assess the severity of a security incident and determine the appropriate response urgency. Use this alongside the specific incident response playbooks.
+
+---
+
+## Severity Matrix
+
+| Priority | Label | Response Time | Description |
+|---|---|---|---|
+| **P1** | Critical | Immediate (< 15 min) | Active data exfiltration, production outage, confirmed breach with customer impact, or regulatory notification required |
+| **P2** | High | < 1 hour | Confirmed compromise with containment needed, lateral movement detected, or privileged credential abuse |
+| **P3** | Medium | < 4 hours | Suspicious activity requiring investigation, potential compromise not yet confirmed, or policy violation with security implications |
+| **P4** | Low | < 24 hours | Informational findings, minor policy violations, or reconnaissance activity with no confirmed impact |
+
+---
+
+## Severity Decision Tree
+
+### Step 1: Is there confirmed unauthorized access?
+
+- **YES** → Go to Step 2
+- **NO, but suspicious activity detected** → Start at **P3**, investigate to confirm or rule out
+- **NO, informational only** → **P4**
+
+### Step 2: Is data confirmed accessed or exfiltrated?
+
+- **YES, customer/personal data** → **P1** (regulatory notification likely required)
+- **YES, internal/operational data** → **P2**
+- **NO, but access to sensitive resources confirmed** → **P2**
+- **UNKNOWN** → Start at **P2**, escalate to P1 if data exposure confirmed
+
+### Step 3: Is the threat actor still active?
+
+- **YES, active session/access** → Escalate one level (minimum **P2**)
+- **NO, access revoked/expired** → Maintain current priority
+- **UNKNOWN** → Treat as active until confirmed otherwise
+
+---
+
+## Escalation Triggers
+
+The following conditions should **immediately escalate** priority regardless of initial assessment:
+
+| Trigger | Escalate To | Rationale |
+|---|---|---|
+| Multiple accounts compromised | P1 | Indicates organizational-level breach |
+| Root account access detected | P1 | Highest privilege, maximum blast radius |
+| Data confirmed exfiltrated externally | P1 | Regulatory notification likely required |
+| Production workloads impacted | P1 | Customer-facing impact |
+| Threat actor has persistence mechanisms | P2 (minimum) | Eradication required before recovery |
+| Lateral movement between accounts | P2 (minimum) | Scope expanding |
+| Credentials posted publicly (e.g., GitHub) | P2 | Race condition with threat actors |
+
+---
+
+## De-escalation Criteria
+
+Priority may be **reduced** when:
+
+| Condition | Action |
+|---|---|
+| Investigation confirms false positive | Close with documented rationale |
+| Scope confirmed limited to non-production, non-sensitive resources | Reduce by one level |
+| Threat actor access confirmed expired with no persistence | Reduce by one level |
+| Automated containment confirmed effective | Maintain priority but reduce urgency |
+
+---
+
+## When to Engage AWS for Support
+
+| Situation | Action | How |
+|---|---|---|
+| Suspected compromise of AWS infrastructure (not your resources) | Contact AWS Security | [aws-security@amazon.com](mailto:aws-security@amazon.com) or [vulnerability reporting](https://aws.amazon.com/security/vulnerability-reporting/) |
+| Need forensic assistance or IR support | AWS Support (any plan level) | Open a support case requesting CIRT assistance |
+| Account access lost / root compromise | AWS Support | Support case (Critical severity) or account recovery |
+| DDoS attack in progress (Shield Advanced) | AWS Shield Response Team | Support case or proactive engagement |
+| Need to preserve evidence beyond your access | AWS Support | Support case with IR context |
+
+### Options for AWS Assistance
+
+**Option 1: AWS Support (any AWS Support plan)**
+Any customer with AWS Support can open a support case and request assistance from the AWS Customer Incident Response Team (CIRT). No additional service subscription is required.
+
+**Option 2: AWS Security Incident Response service (if enabled)**
+The [AWS Security Incident Response](https://aws.amazon.com/security-incident-response/) service provides additional capabilities for customers who have enabled it:
+- Automated triage of security findings from GuardDuty and Security Hub
+- 24/7 access to the AWS Customer Incident Response Team (CIRT)
+- Dedicated case management and coordination
+- Post-incident reporting
+
+**When to engage AWS:**
+- Any P1 or P2 incident where you need expert assistance
+- When you're unsure about scope or containment effectiveness
+- When the incident involves AWS service-level concerns
+- When you need help with evidence preservation
+
+---
+
+## Initial Response Checklist (All Priorities)
+
+Regardless of priority, the first responder should:
+
+- [ ] **Document the trigger** — What alert, finding, or report initiated this?
+- [ ] **Timestamp everything** — Note when you were notified and when you began response (UTC)
+- [ ] **Assess scope** — How many accounts, regions, and resources are potentially affected?
+- [ ] **Preserve evidence** — Do NOT terminate instances, delete logs, or modify resources before capturing state
+- [ ] **Assign priority** — Use the matrix above
+- [ ] **Notify stakeholders** — Per your organization's communication plan
+- [ ] **Open a case** — In your incident tracking system
+- [ ] **Begin playbook** — Select the appropriate playbook based on incident type
+
+---
+
+## Incident Type Quick Reference
+
+| Indicators | Likely Scenario | Playbook |
+|---|---|---|
+| Unusual API calls from unknown IP, new access keys created | Credential compromise | [IRP-CredCompromise](playbooks/IRP-CredCompromise.md) |
+| Large data transfers, S3 GetObject spikes, unusual Macie findings | Data exfiltration | [IRP-S3DataExfiltration](playbooks/IRP-S3DataExfiltration.md) |
+| GuardDuty CryptoCurrency findings, CPU spikes, unusual instance types | Cryptomining | [IRP-Cryptomining](playbooks/IRP-Cryptomining.md) |
+| Encrypted volumes, ransom notes, backup deletion attempts | Ransomware | [IRP-Ransomware](playbooks/IRP-Ransomware.md) |
+| AssumeRole chains, cross-account activity, unusual federation | STS token abuse | [IRP-STSTokenAbuse](playbooks/IRP-STSTokenAbuse.md) |
+| SSO permission changes, new assignments, IdP configuration changes | Identity Center compromise | [IRP-IdentityCenterCompromise](playbooks/IRP-IdentityCenterCompromise.md) |
+| Traffic spikes, 5xx errors, Shield/WAF alerts | DoS/DDoS | [IRP-DoS](playbooks/IRP-DoS.md) |
+| Pod escape, container runtime alerts, Kubernetes audit anomalies | Container/EKS compromise | [IRP-ContainerEKSCompromise](playbooks/IRP-ContainerEKSCompromise.md) |
+| Build artifact changes, dependency alerts, pipeline modifications | CI/CD compromise | [IRP-CICDCompromise](playbooks/IRP-CICDCompromise.md) |
+| Root login, MFA changes, account recovery attempts | Root account takeover | [IRP-AccountTakeoverRoot](playbooks/IRP-AccountTakeoverRoot.md) |
+| C2 traffic, reverse shells, IMDS access from unusual processes | EC2 compromise | [IRP-EC2Compromise](playbooks/IRP-EC2Compromise.md) |
+| Off-hours bulk access, privilege escalation by authorized user | Insider threat | [IRP-InsiderThreat](playbooks/IRP-InsiderThreat.md) |
+| SAML assertion anomalies, IdP config changes, federated session abuse | Federated access abuse | [IRP-FederatedAccessAbuse](playbooks/IRP-FederatedAccessAbuse.md) |
+| Personal data access confirmed, Macie PII findings | Personal data breach | [IRP-PersonalDataBreach](playbooks/IRP-PersonalDataBreach.md) |
+
+---
+
+## References
+
+- [NIST SP 800-61r3: Incident Response Recommendations](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide (2023)](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html)
+- [AWS Security Incident Response Service](https://aws.amazon.com/security-incident-response/)

--- a/ai-playbooks/steering/README.md
+++ b/ai-playbooks/steering/README.md
@@ -5,13 +5,9 @@ These markdown documents are created to be used as templates only. They should b
 
 These markdown documents are written to facilitate editing and consumption into a variety of integrated development environments ("IDE"s) as guidance files. [In Kiro, these are known as "steering files"](https://kiro.dev/docs/steering/) and [in Claude Code, they are known as "skills"](https://code.claude.com/docs/en/skills). In both examples, the files are written in markdown for consumption into the relevant IDE.
 
-<<<<<<< HEAD:ai-playbooks/README.md
 Note that you need to copy the files in this repo into the correct directory in your IDE. In Kiro, we recommend setting up a new project, and defining a [workspace](https://kiro.dev/docs/steering/) and keeping your steering files in the steering directory *for the workspace*.
 
-The markdown documents included cover several common scenarios faced by AWS customers. They outline steps based on the [NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) and codify these steps as structured guidance that AI agents can use to assist a human operator investigate and resolve an incident. This includes the following steps outlined by NIST:
-=======
 The markdown documents included cover several common scenarios faced by AWS customers. They outline steps based on the [NIST Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final) (Special Publication 800-61 Revision 3) and codify these steps as structured guidance that AI agents can use to assist a human operator investigate and resolve an incident. This includes the following steps outlined by NIST:
->>>>>>> upstream/master:ai-playbooks/steering/README.md
 
 * Gather evidence
 * Contain and then eradicate the incident


### PR DESCRIPTION
- Replace README with updated version (NIST r3, 2023 IR Guide, full playbook index)
- Replace CONTRIBUTING.md with expanded guidance (AI contributions, testing methodology)
- Add PLAYBOOK_TEMPLATE.md (standardized structure for all playbooks, CSF 2.0 mapped)
- Add TRIAGE_GUIDE.md (P1-P4 severity matrix and decision tree)
- Add REGULATORY_CONTEXT.md (notification obligations by regulation and incident type)
- Add GitHub Actions workflow (markdownlint + link checker)
- Add .markdownlint.json configuration
- Fix merge conflict in ai-playbooks/steering/README.md (keep r3 reference)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
