### PR TITLE
Refresh existing playbooks (NIST SP 800-61r3 alignment)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,5 +5,8 @@
   "MD041": false,
   "MD024": {
     "siblings_only": true
-  }
+  },
+  "MD026": false,
+  "MD036": false,
+  "MD060": false
 }

--- a/playbooks/IRP-CredCompromise.md
+++ b/playbooks/IRP-CredCompromise.md
@@ -1,147 +1,556 @@
-# Incident Response Playbook Template
+# IRP-CredCompromise: IAM Credential Compromise
 
-### Incident Type
+> **Playbook Version:** 2.0
+> **Last Reviewed:** 2026-06-18
+> **Status:** `Active`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-STSTokenAbuse](IRP-STSTokenAbuse.md) | [IRP-IdentityCenterCompromise](IRP-IdentityCenterCompromise.md) | [IRP-FederatedAccessAbuse](IRP-FederatedAccessAbuse.md) | [IRP-Ransomware](IRP-Ransomware.md)
 
-Credential Leakage/Compromise
-
-### Introduction
-
-This playbook is provided as a template to customers using AWS products and who are building their incident response capability.  You should customize this template to suit your particular needs, risks, available tools and work processes.
-
-Security and Compliance is a shared responsibility between you and AWS. AWS is responsible for “Security of the Cloud”, while you are responsible for “Security in the Cloud”. For more information on the shared responsibility model, [please review our documentation](https://aws.amazon.com/compliance/shared-responsibility-model/).
-
-You are responsible for making your own independent assessment of the information in this document. This document: (a) is for informational purposes only, (b) references current AWS product offerings and practices, which are subject to change without notice, and (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. This document is provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
-
-## Summary
-
-### This Playbook
-This playbook outlines response steps for Credential Leakage/Compromise incidents.  These steps are based on the [NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) that can be used to:
-
-* Gather evidence
-* Contain and then eradicate the incident
-* Recover from the incident
-* Conduct post-incident activities, including post-mortem and feedback processes
-
-Interested readers may also refer to the [AWS Security Incident Response Guide]( https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) which contains additional resources.
-
-Once you have customized this playbook to meet your needs, it is important that you test the playbook (e.g., Game Days) and any automation (functional tests), update as necessary to achieve the desired results, and then publish to your knowledge management system and train all responders.
-
-Note that some of the incident response steps noted in each scenario may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing these scenarios and testing them will help you to determine if additional costs will be incurred. You can use [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be.
-
-In reviewing this playbook, you will find steps that involve processes that you may not have in place today. Proactively preparing for incidents means you need the right resource configurations, tools and services in place that allow you to respond to an incident.
-The next section will provide a summary of this incident type, and then cover the five steps (parts 1 - 5) for handling credential compromise.
-
-### This Incident Type
-Credential compromise occurs when credentials related to one or more of your IAM principals (such as an IAM user or role) have been obtained by an actor not authorized to use them. This means that the actor is either *not* the IAM user whom the credentials identify, or is not authorized to assume the IAM role that a set of temporary credentials are associated with. Once a malicious actor has obtained a set of credentials, they can use those credentials to perform any action that is allowed by IAM policies associated with those credentials. This may include the ability to elevate privilege if those allowed actions include various IAM API actions, such as PassRole, CreateUser or Attach*Policy. As a preventative measure, you can use AWS IAM Permission Boundaries and AWS Organizations Service Control Policies (SCPs) to scope down user permissions and prevent potential privilege escalations.
-
-## Incident Response Process
 ---
-### Part 1: Acquire, Preserve, Document Evidence
 
-1. You become aware of potential indicators of compromise (IoCs). These could come in various forms:
-    - An internal ticketing system (the sources of the ticket are varied and could include any of the means below)
-    -	A message from a contractor or third-party service provider
-    -	From an alert in one of your monitoring systems either inside or external to AWS (for example, in AWS, in this particular situation, it could be via an Amazon GuardDuty finding, either directly in GuardDuty, or via AWS Security Hub, or it could be via a [CloudWatch metric indicating a change in IAM]( https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudwatch-alarms-for-cloudtrail.html#cloudwatch-alarms-for-cloudtrail-iam-policy-changes) or from your own systems ingesting AWS data)
-    - Alarms or observations that resources have been created in your account that cannot be accounted for in your CMDB, exist in regions that you do not operate infrastructure in, or themselves have generated alerts ([[Amazon Detective]( https://aws.amazon.com/detective/getting-started/) is a useful tool for understanding these relationships)
-    - Via an anonymous tip
-    - Via independent or external security researchers
-    - Where credentials have been compromised, you are less likely to be contacted via the threat actor, as in this situation typically they want to maximize their use of resources and minimize the chance of being discovered, unless the compromise is being used to exfiltrate data or cause some other kind of public incident such as through the modification of your publicly facing resources
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
 
-2. Confirm a ticket/case has been raised for the incident. If not, manually raise one
-3. Determine and begin to document any end-user impact/experience of the issue. From a user’s perspective, for this type of scenario, there may be no direct user impact. Findings should be documented in the ticket/case related to the incident
-4. In the case of automatically created tickets/cases, determine what internal alarms/metrics are currently indicating an issue (what caused the ticket to be created?) This may be an Amazon CloudWatch metric indicating an API was called that included a reference to an AWS policy, or an AWS Config rule that indicates some aspect of your AWS Identity and Access Management (IAM) configuration has fallen out of compliance, or an Amazon GuardDuty alert that indicates possible credential compromise. It may also be a billing alert where your billing costs have passed a predetermined threshold, triggering an alarm and notification. Determine exactly which of these has caused the ticket/case to be raised
-5. Determine the set of credentials that have been compromised. Note that there will be additional steps in Part 3 to deal with scenarios where threat actors have planted resources to gain an account foothold.
-    1. If an internal ticket/case has been created, review the case to determine if the user/role name or ARN, user or role ID, or Access Key ID are provided in that ticket. If it is not, reference the alert specified in the ticket (for example, a GuardDuty finding) and go to point 2., below
-    2. If the alert has come from GuardDuty or AWS Security Hub, locate the specific event in the service’s AWS console and then locate the Access Key ID for the impacted credentials. In GuardDuty, this will be located under the “Resource” section of the finding. “resourceType” should be Access Key and there will be a field named accessKeyDetails that will contain the Access Key ID, Principal ID, User Type and additional information
-6. Determine the likely time at which the credentials were compromised (any API actions taken post that time should be considered as malicious and any resources created post that time should be considered compromised). As an example, for a GuardDuty finding, note the “eventFirstSeen” field in the “Service” section of the finding.
-7. If there is service disruption for your application occurring (see point 2, above), determine if there are any known events that could be causing that disruption that may not be related to the credential leakage (deployed CRs or other application modifications, for example). Check the deployment pipeline to determine if any changes have been made leading up to the event (the time the event was first recorded, or the time the automated system cut the ticket/case)
-8. Incident Communications:
-    1. Identify stakeholder roles from the application entry in the Configuration Management Database (CMDB) entry for that application, or via the application’s risk register
-    2. Open a conference bridge war room for the incident
-    3. Notify identified stakeholders including (if required) legal personnel, technical teams and developers and add them to the ticket and the war room, so they are updated as the ticket is updated
-9.	External Communications:
-    1. Ensure your organizations legal counsel is informed and is included in status updates to internal stakeholders and especially in regards to external communications.
-    2. For colleagues in the organization that are responsible for providing public/external communication statements, ensure these internal stakeholders are added to the ticket so they receive regular status updates regarding the incident and can complete their own requirements for communications within and external to the business.
-    3. If there are regulations in your jurisdiction requiring reporting of such incidents, ensure the people in your organization responsible for notifying local or federal law enforcement agencies are also notified of the event/added to the ticket. Consult your legal advisor and/or law enforcement for guidance on collecting and preserving the evidence and chain of custody.
-    4. There may not be regulations, but either open databases, government agencies or NGOs may track this type of activity. Your reporting may assist others
+---
 
-### Part 2: Contain the Incident
+## Overview
 
-The immediate task will be to disable compromised credentials or revoke permissions associated with those credentials, thereby preventing any further API activity using the compromised credentials.
+IAM credential compromise occurs when an unauthorized party obtains valid AWS credentials — long-term access keys, console passwords, or session tokens — and uses them to access AWS resources. This is one of the most common incident types in AWS environments. Compromised credentials may be obtained through phishing, credential stuffing, accidental exposure in public repositories, malware on developer workstations, or social engineering. The scope of impact depends on the permissions attached to the compromised principal and how quickly the compromise is detected and contained.
 
-1. For the compromised credential identified from Part 1, disable those credentials
-    1. If they are long term IAM user credentials, [disable them using the IAM console or API](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
-    2. If they are short term credentials obtained via the AWS Security Token Service (AWS STS) they will be associated with an IAM role. There are a couple of options available to disable these:
-        1. [Revoke all current role sessions](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html) (note that if the threat actor has the ability to obtain new credentials, this won’t solve the problem)
-        2. If the threat actor is able to obtain another set of credentials and the activity continues, it will then be necessary to remove all IAM policies attached to the role, modify the attached policies to block all access, or modify the role’s trust policy to prevent the actor from assuming the role. As the credentials will remain valid for the specified time duration once issued, it is important to note that modifying the trust policy will allow any current valid credentials to continue to be used whilst still valid
-            **Note that the above actions (step 2, substeps 1 and 2) will stop all users from using credentials obtained by assuming the role, including any legitimate users or applications**
-2. The compromised credentials should now be disabled. Verify this by checking the AWS CloudTrail console for the next 30 minutes or so for ongoing credential use, whether by access key, IAM user, or Role.
+### Out of Scope
 
-### Part 3: Eradicate the Incident
+This playbook does **not** cover:
 
-Now it is time to further investigate what API actions the compromised credentials have performed since the compromise occurred, and then determine if additional resources need to be deleted, terminated, or investigated further. From Part 1, you have identified the compromised credentials, and the likely time of compromise. It will now be necessary to determine what API actions have been performed and what resources have been created, deleted or modified after that time.
+- **STS temporary credential abuse via AssumeRole chains** — If the primary vector is cross-account role assumption or session token manipulation without initial long-term credential theft, see [IRP-STSTokenAbuse](IRP-STSTokenAbuse.md). (Coming Soon)
+- **Identity Center (SSO) compromise** — If the compromise involves AWS Identity Center permission sets or SSO sessions, see [IRP-IdentityCenterCompromise](IRP-IdentityCenterCompromise.md). (Coming Soon)
+- **Federated identity / IdP compromise** — If the initial compromise is at the identity provider level (Okta, Azure AD, etc.) leading to AWS access, see [IRP-FederatedAccessAbuse](IRP-FederatedAccessAbuse.md). (Coming Soon)
+- **Ransomware resulting from credential compromise** — Once containment here is complete, pivot to [IRP-Ransomware](IRP-Ransomware.md) if encryption or extortion activity is detected.
 
-1. Using your preferred monitoring tool, access CloudTrail and search for all API actions performed by the compromised credentials, from the date and time of compromise through to the current time:
-    1. If this tool is a third-party tool such as Splunk, Sumo Logic or others, follow the normal procedure for obtaining log information from that tool
-    2. If you do not ingest CloudTrail logs into a third-party tool, but do send those logs to Amazon Simple Storage Service (Amazon S3), you will be able to use Amazon Athena to query the logs. The remaining steps will focus on AWS tools to retrieve the necessary information
-2. [Create an Athena table referencing the bucket containing your CloudTrail logs](https://aws.amazon.com/premiumsupport/knowledge-center/athena-tables-search-cloudtrail-logs/) that link also includes example queries that can be run in Athena
-3. In the Athena console, run a query that shows all API actions taken by the compromised credentials post-compromise date/time
-4. From the resulting list, determine which API calls:
-    - Accessed sensitive data (such as S3 GetObject)
-    - Created new AWS resources, such as databases, Amazon Elastic Compute Cloud (Amazon EC2) instances, AWS Lambda functions or S3 buckets, etc.
-    - Services that create resources  should also be carefully checked [for ….], these include Amazon EC2 Auto Scaling Groups, Amazon EC2 Spot Fleets, Amazon Elastic Kubernetes Service (Amazon EKS)/Amazon Container Service (Amazon ECS) clusters, etc.
-    - Created or modified AWS identity resources that could be used to extend a foothold into the account (or other accounts, for example with AWS Security Token Service (AWS STS) API methods such as AssumeRole). Within an account, API methods including (but not limited to) the following should also be investigated:
-        - CreateUser
-        - CreateRole
-        - AssumeRole*
-        - Get*Token
-        - Attach*Policy
-        - RunInstances (especially with PassRole)
-        - \*Image*
-        - *Provider
-        - Tag*
-        - Untag*
-        - Create*
-        - Delete*
-        - Update*
-        - etc.
-    4. Deleted existing AWS resources
-    5. Modified existing AWS resources
-5. Based on the results of the previous step, determine if any applications are potentially impacted:
-    1. Obtain the ARN and/or tag information for each resource impacted (from step 4, above)
-    2. Go back to the CMDB and determine which application that resource belongs to
-    3. Notify the application owner based on the results of the above steps
-6. Based on the above results, if additional credential-obtaining resources have been created (IAM users, roles, EC2 instances with roles, etc.), take the following steps:
-    1. Disable and/or delete any credentials for those resources, as per the steps outlined in Part 2, Step 1
-    2. Use your preferred logging tool to analyze CloudTrail again, this time specifying the additionally discovered credentials as a query parameter, as outlined in Part 3, steps 1 through to 6 (this step). Continue to iterate through this process until you discover that there were no further resources created capable of obtaining valid credentials for the AWS account.
-    3. For each set of newly discovered compromised credentials, go through the following steps from 7 in Part 3 (below) and all relevant steps in Part 4, also below
-7. For new resources created during the compromise: Delete all resources created by the compromised credentials that were created post the date/time of the compromise occurring
-8. For handling resources that were modified or deleted during the compromise, see Part 4
+### Applicable Finding Types
 
-### Part 4: Recover from the Incident
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon GuardDuty | `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.OutsideAWS` | HIGH |
+| Amazon GuardDuty | `UnauthorizedAccess:IAMUser/InstanceCredentialExfiltration.InsideAWS` | HIGH |
+| Amazon GuardDuty | `UnauthorizedAccess:IAMUser/ConsoleLoginSuccess.B` | MEDIUM |
+| Amazon GuardDuty | `Discovery:IAMUser/AnomalousBehavior` | LOW |
+| Amazon GuardDuty | `Persistence:IAMUser/AnomalousBehavior` | MEDIUM |
+| Amazon GuardDuty | `CredentialAccess:IAMUser/AnomalousBehavior` | MEDIUM |
+| Amazon GuardDuty | `InitialAccess:IAMUser/AnomalousBehavior` | MEDIUM |
+| AWS Security Hub | IAM Access Analyzer external access findings | HIGH |
+| AWS Security Hub | IAM Access Analyzer unused access findings | MEDIUM |
+| CloudTrail | `eventName: CreateAccessKey` (for unexpected principals) | — |
+| CloudTrail | `eventName: ConsoleLogin` (from unusual sourceIP/userAgent) | — |
+| CloudTrail | `eventName: GetCallerIdentity` (reconnaissance indicator) | — |
+| Third-Party | GitHub/GitLab secret scanning alerts | HIGH |
+| Third-Party | SIEM correlation: impossible travel, credential stuffing patterns | MEDIUM |
 
-1. For resources that were modified during the compromise:
-    1. If the resource can be destroyed and replaced, do so. For example, EC2 instances in an EC2 Auto Scaling group, with a Launch Configuration referencing a non-compromised AMI, or Launch Templates used to create EC2 instances, terminate the instance, allow EC2 Auto Scaling to add a new one
-    2. If the resource cannot be replaced, either:
-        1. Restore the resource from a known good backup, or;
-        2. Prepare a new resource and configure it into the application’s infrastructure, while isolating the compromised resource and removing it from the application’s infrastructure. Update the CMDB accordingly
-        3. Either destroy the compromised resource, or continue to leave it isolated for post-incident forensics
-2. For resources that were deleted during the compromise:
-    1. Determine what (if any) application the resource belonged to, by checking in the CMDB, or confirming the resource’s tag(s) (Check AWS Config if the tags aren’t listed in the CloudTrail entry and the [resource is supported by AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html))
-    2. If the deleted resource can be restored from backup, commence the restore procedure
-    3. If the deleted resource cannot be restored from backup, consult the CMDB to obtain the resource’s configuration, and recreate the resource and configure it into the application’s infrastructure
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
 
-### Part 5: Post-Incident Activity
+### Severity Classification
 
-This activity contains two parts. Firstly, some compromised resources may require forensic analysis, either to fulfil regulatory obligations or improved incident handling, both taking input from the root cause analysis that will result from forensic investigation. The second part is a “sharpen the saw” activity which helps teams to assess their response to the actual incident, determine what worked and what didn’t, update the process based on that information and record these findings.
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | Confirmed credential use with data access/exfiltration, resource creation in production accounts, or lateral movement to additional accounts |
+| **P2 — High** | Confirmed unauthorized API calls from compromised credential, scope unclear, or credential exposed publicly (GitHub, paste site) |
+| **P3 — Medium** | Anomalous behavior detected on a principal (unusual IP, user agent, or API pattern) but no confirmed malicious action yet |
+| **P4 — Low** | Stale credential identified with no evidence of use, or policy violation (e.g., access key older than 90 days) |
 
-Firstly, perform any required forensic investigation to determine (for compromised resources) what methods the actors may have used and to determine if additional risks and risk mitigations are required for the resources and/or applications in question.
+---
 
-1. For any compromised resources that have been isolated for further analysis, perform the forensic activity on those resources and incorporate the findings into the post-incident report.
-2. Ensure that the CMDB is correctly updated to reflect the current status of all resources and applications impacted
+## Part 1 — Prepare
 
-Secondly, review the incident itself and the response to it, to determine if anything needs to be changed for handling any similar incidents in the future.
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
 
-1. Review the incident handling and the incident handling process with key stakeholders identified in Part 1, Step 8.
-2. Document lessons learned, including attack vector(s) mitigation(s), misconfiguration, etc.
-3. Store the artifacts from this process with the application information in the CMDB entry for the application and also in the CMDB entry for the credential compromise response process.
+### 1.1 Recommended AWS Service Configurations
+
+The following services each contribute to your ability to detect, investigate, and respond to credential compromise. None are strictly required, but each addresses a specific gap — the more you have enabled, the faster you can detect anomalous activity and the more complete your forensic picture will be during an investigation.
+
+- [ ] **Amazon GuardDuty** enabled in all regions with findings exported to Security Hub — provides continuous threat detection for IAM anomalies, credential exfiltration, and reconnaissance patterns
+- [ ] **AWS CloudTrail** enabled with multi-region trail, management events, and integrity validation — the primary audit log for all API activity; without it, investigation is severely limited
+- [ ] **CloudTrail Insights** enabled — detects unusual API call volume that may indicate automated credential abuse
+- [ ] **AWS Config** enabled with IAM-related rules (e.g., `iam-user-mfa-enabled`, `access-keys-rotated`) — provides continuous compliance assessment of IAM configuration
+- [ ] **IAM Access Analyzer** enabled (both external access and unused access analyzers) — identifies overly permissive or unused access that increases the scope of impact if a credential is compromised
+- [ ] **Amazon Detective** enabled — provides graph-based investigation of credential usage patterns, reducing time to scope an incident
+- [ ] **AWS Security Hub** enabled with AWS Foundational Security Best Practices standard — aggregates and prioritizes findings across services into a single pane
+- [ ] **CloudWatch alarms** configured for root account usage and console login failures — provides immediate alerting on high-risk authentication events
+- [ ] **S3 bucket for CloudTrail logs** has Object Lock or versioning enabled — protects audit trail from tampering by a threat actor who gains administrative access
+
+> 🤖 **Automation opportunity:** Deploy the [AWS Security Hub Automated Response and Remediation (SHARR)](https://aws.amazon.com/solutions/implementations/automated-security-response-on-aws/) solution to auto-remediate common IAM findings.
+
+> 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
+
+### 1.2 IAM & Access Prerequisites
+
+Effective incident response depends on having the right access available *before* an incident occurs. Provisioning break-glass access during an active compromise wastes time, may be blocked by the threat actor, and introduces risk of error under pressure. The following recommendations align with [SEC10-BP05 Pre-provision access](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_provision_access.html) from the AWS Well-Architected Framework.
+
+- [ ] **Break-glass IAM role** exists in each account with scoped permissions to: list/delete access keys, deactivate MFA, attach deny policies, query CloudTrail, and export GuardDuty findings — pre-tested and documented
+- [ ] **IR team members can assume the break-glass role** with MFA from a trusted (non-production) account — validate this works at least quarterly
+- [ ] **Deny-all IAM policy** is pre-created and ready to attach during containment (see [Part 3 — Contain](#part-3--contain))
+- [ ] **Forensic account** is available for cross-account log analysis — isolated from production, with appropriate trust relationships pre-configured
+- [ ] **IAM credential report** generation tested and accessible — confirm responders know how to generate and interpret it
+- [ ] **Access to AWS Security Incident Response console** confirmed, if subscribed — verify case creation workflow before you need it
+
+> 📖 **Reference:** [AWS Security Incident Response Guide — Preparation](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/preparation.html) — covers pre-provisioning access, establishing forensic accounts, and validating response capabilities.
+
+### 1.3 Communication & Escalation
+
+Clear communication paths reduce confusion during high-pressure incidents. Define who needs to be involved, at what severity threshold, and through which channel *before* you need them. The goal is to avoid spending incident time figuring out who to call.
+
+> 📋 Do not include names in this playbook. Use roles only. Maintain a separate, access-controlled contact list (e.g., internal wiki, sealed envelope, or secure document) with current names, phone numbers, and escalation preferences.
+
+| Role | Responsibility | When to Engage |
+|---|---|---|
+| IR Lead | Overall incident coordination, status updates, decision authority for containment actions | All severity levels — first notified |
+| Account Owner | Business context, authorization for credential revocation, impact assessment | P1–P3, or when containment may disrupt services |
+| Application Owner | Impact assessment of credential rotation on running services, identification of dependent systems | When the compromised credential is used by applications or automation |
+| Legal / Compliance | Regulatory notification assessment, evidence preservation hold, breach counsel | P1–P2, or when regulated data may have been accessed |
+| AWS Support / AWS CIRT | Technical assistance with scoping, containment guidance, threat intelligence | P1–P2 via AWS Support case (any support plan) or Security Incident Response service (if subscribed) |
+
+**Escalation path:**
+
+1. **Detection:** Automated alert (GuardDuty, secret scanning, SIEM) or human report triggers initial notification.
+2. **Triage (IR Lead, < 15 min):** IR Lead assesses severity using [Section 2.3](#23-severity-determination). Determines if the credential is still active and whether unauthorized use is confirmed.
+3. **Severity-based escalation:**
+   - **P1/P2:** IR Lead notifies Account Owner and Legal/Compliance immediately. Opens AWS Support case (severity: Critical) requesting CIRT assistance. If AWS Security Incident Response service is enabled, creates a case there instead.
+   - **P3/P4:** IR Lead manages internally with Application Owner. Escalates to P2 if investigation confirms unauthorized use.
+4. **Status updates:** IR Lead provides updates to stakeholders every 30 minutes (P1), every 2 hours (P2), or at key milestones (P3/P4).
+
+> 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — recommends identifying and documenting internal and external resources and contact information ahead of time.
+
+### 1.4 Game Day Guidance
+
+Practicing incident response before a real incident occurs builds muscle memory, identifies gaps in tooling and access, and validates that escalation paths work. Teams that exercise regularly contain incidents faster.
+
+Recommended testing cadence: **Semi-annually** (this is a P1-capable scenario).
+
+Suggested tabletop scenario:
+> *"A developer's long-term access key has been found in a public GitHub repository. The key has AdministratorAccess permissions in a production account. GitHub's secret scanning alert fired 4 hours ago. You don't know if anyone else has already used the key."*
+
+**Practice resources (no paid service or support plan required):**
+
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/) — free, hands-on workshops covering credential compromise, S3 ransomware, and more. Deployable in any AWS account.
+- [AWS Security Workshops catalog](https://workshops.aws/categories/Security) — broader collection of security-focused hands-on labs.
+
+> 📖 **Reference:** [SEC10-BP04 Develop and test security incident response playbooks](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_playbooks.html) — recommends creating and regularly testing playbooks to verify response processes.
+
+---
+
+## Part 2 — Detect & Analyze
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyze)
+> **Goal:** Determine whether the credential activity is authorized or unauthorized, understand the scope if it is unauthorized, and document the evidence needed to support containment and recovery decisions.
+
+### 2.1 Initial Triage Questions
+
+Not every alert is a confirmed compromise. The purpose of triage is to quickly determine whether you are dealing with a true positive (unauthorized use), a potential compromise requiring investigation, or a false positive that can be closed. Answer these questions to establish scope and urgency — each should take less than 2 minutes.
+
+- [ ] What type of credential is involved? (Long-term access key, console password, session token, SAML assertion)
+- [ ] How was the activity detected? (GuardDuty, secret scanning, user report, third-party notification)
+- [ ] Is the activity confirmed unauthorized, or could it be legitimate but unusual? (New region, new service, off-hours access by an on-call engineer)
+- [ ] What permissions does the principal have? (Check IAM policies — inline, attached, group-inherited, permission boundaries)
+- [ ] Which accounts and regions could this principal access? (Check trust policies, resource policies, SCPs)
+- [ ] Is the credential still active? (`aws iam get-access-key-last-used` or credential report)
+- [ ] Is there evidence the credential has been used from an unfamiliar source? (Unusual IPs, user agents, geographic locations)
+- [ ] Are production workloads or sensitive data accessible with this credential?
+- [ ] Could persistence mechanisms have been created? (New access keys, roles, users, Lambda functions)
+
+**If the credential has admin-level permissions AND evidence of unauthorized use → P1 immediately.**
+**If the activity is anomalous but could be legitimate → investigate further before containment (avoid unnecessary disruption).**
+
+### 2.2 Evidence Documentation
+
+Whether the activity is confirmed malicious or still under investigation, document the current state of the credential and its usage. For IAM credential scenarios, the primary evidence source is AWS CloudTrail. The priority here is *documenting what you observe* rather than copying logs to a separate location.
+
+> 📌 **Note on evidence storage:** If you have a dedicated forensic S3 bucket or SIEM, export findings there. If you don't, that's fine — CloudTrail logs, GuardDuty findings in the console, and notes in your IR ticket or documentation tool are sufficient for this scenario.
+
+**Document the following:**
+
+| What to Document | How | Notes |
+|---|---|---|
+| Credential details (key ID, user, creation date) | `aws iam list-access-keys --user-name USER` | Establishes which credential is under review |
+| When the credential was last used | `aws iam get-access-key-last-used --access-key-id AKIA...` | Determines if credential is actively in use |
+| IAM credential report (all users) | `aws iam generate-credential-report && aws iam get-credential-report` | Provides full picture of credential posture |
+| Permissions attached to the principal | `aws iam list-attached-user-policies` / `list-user-policies` / `list-groups-for-user` | Determines scope of impact |
+| Source IPs and user agents in CloudTrail | Athena query or CloudTrail console (see below) | Distinguishes legitimate vs. unfamiliar usage |
+| GuardDuty findings for the principal | GuardDuty console → filter by resource | May provide additional context on the nature of the activity |
+| IAM Access Analyzer findings | Security Hub or IAM Access Analyzer console | Shows if the principal has external or unused access |
+| Resources created or modified by the principal | CloudTrail filtered by `userIdentity.accessKeyId` | Identifies potential persistence or damage |
+
+**CloudTrail / Athena investigation queries:**
+
+For detailed Athena queries to investigate credential usage (source IP analysis, persistence detection, data access events, cross-account role assumptions), see:
+
+📁 [`resources/athena-queries-credential-compromise.sql`](resources/athena-queries-credential-compromise.sql)
+
+**Quick CloudTrail Console approach (no Athena required):**
+
+If Athena is not configured, you can investigate directly in the CloudTrail console:
+1. Navigate to **CloudTrail → Event history**
+2. Filter by **User name** = the IAM user under investigation
+3. Review source IPs — compare against known corporate IP ranges
+4. Look for API calls you don't expect from this user (e.g., `CreateAccessKey`, `AssumeRole` to unfamiliar accounts)
+5. Check the time range — activity outside normal working hours from unfamiliar IPs is a strong indicator
+
+### 2.3 Severity Determination
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Admin credential used from unknown IP, resources created or data accessed | P1 |
+| Credential confirmed used by unauthorized party, scope unclear | P2 |
+| Credential exposed publicly but no evidence of unauthorized use yet | P2 |
+| Anomalous behavior on principal, compromise not confirmed | P3 |
+| Stale/unused credential found, no evidence of abuse | P4 |
+
+### 2.4 Getting Help from AWS
+
+For P1, P2, or P3 incidents, consider engaging AWS for support. AWS Support and AWS CIRT can help you determine whether activity is truly unauthorized, assist with scoping the impact, and advise on containment approaches — you do not need to be certain of a compromise before reaching out.
+
+- **AWS Security Incident Response service** (if enabled): Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose **Active Security Incident** for urgent support or **Investigations and Inquiries** for log analysis and secondary confirmation of findings.
+- **AWS Support** (any support plan): Open a support case requesting assistance from the AWS Customer Incident Response Team (CIRT). Include the finding ID(s), the credential under investigation, and a summary of the anomalous behavior you have observed.
+
+> 📌 You do not need the Security Incident Response service to get help experts. All AWS customers can request CIRT assistance through a support case, regardless of support plan level. For P3 (anomalous behavior, not yet confirmed), AWS CIRT can help you determine whether the activity is malicious or legitimate.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Prevent further unauthorized API activity using the credential under investigation, while minimizing disruption to legitimate users and services. Containment should be deliberate — deactivate credentials rather than delete them, so you can observe what breaks and retain forensic value.
+
+### 3.1 Containment Decision
+
+The goal of containment is to disable the credential so it can no longer be used, while understanding the impact of that action. Deactivating (not deleting or revoking) is preferred because it allows you to: (1) observe if legitimate services or users are impacted, (2) retain the credential ID for CloudTrail investigation, and (3) reverse the action quickly if the alert turns out to be a false positive.
+
+```
+Has the credential been confirmed used by a threat actor?
+│
+├── YES (confirmed unauthorized use from unfamiliar source)
+│     └── Proceed to 3.2 immediately — deactivate the credential
+│
+├── EXPOSED but no confirmed use yet (e.g., GitHub secret scan, paste site)
+│     └── Proceed to 3.2 immediately — the threat actor may already have it
+│         and is waiting to use it; time advantage matters
+│
+└── ANOMALOUS but unconfirmed (unusual IP or API pattern, could be legitimate)
+      └── Investigate further (Part 2) before taking containment action
+            ├── If confirmed unauthorized → Proceed to 3.2
+            ├── If confirmed legitimate → Document and close
+            └── If still unclear after 30 min → Consider engaging AWS CIRT (Section 2.4)
+                  for help determining if the activity is malicious
+```
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates. `[Account Owner]` authorizes. `[Application Owner]` assesses service impact of credential deactivation.
+
+The containment approach depends on the type of credential involved. In all cases, the immediate task is to disable the credential or restrict permissions associated with it, preventing further API activity.
+
+#### If the credential is a long-term IAM user access key:
+
+1. **Deactivate the access key** using the IAM console or CLI. Do not delete it — deactivation preserves the key ID for CloudTrail queries and can be reversed if needed.
+2. **Monitor CloudTrail** for the next 30 minutes to confirm the credential is no longer being used. If you see continued activity from the same `accessKeyId`, the deactivation may not have propagated yet (allow a few minutes) or additional credentials may be in play.
+3. **Note any service disruption** — if legitimate applications were using this key, they will begin failing. Document what breaks so you can address it during recovery.
+
+
+#### If the credential is a console password:
+
+1. **Attach an explicit deny-all inline policy** to the IAM user. This immediately blocks all API and console actions while preserving the user account for investigation.
+2. **Consider deleting the login profile** (console password) if the threat actor may have changed the password or registered their own MFA device.
+3. **Check for MFA devices** — if the threat actor registered an MFA device, deactivate it.
+
+> 📌 There is no "deactivate" for console passwords. Attaching a deny-all inline policy is the fastest way to contain console access without destroying the user's configuration.
+
+#### If the credential is a short-term STS token (associated with an IAM role):
+
+Short-term credentials obtained via AWS STS are associated with an IAM role and will remain valid until they expire (default up to 1 hour, configurable up to 12 hours). There are several options to contain these:
+
+1. **Revoke current role sessions** by attaching an inline policy with a `DateLessThan` condition on `aws:TokenIssueTime`. This invalidates all temporary credentials issued before the current timestamp. Note: if the threat actor can obtain new credentials (still has the ability to call `AssumeRole`), this alone will not solve the problem.
+
+2. **If the threat actor continues to obtain new credentials**, it will be necessary to take additional action:
+   - Remove or modify IAM policies attached to the role to block access
+   - Modify the role's trust policy to prevent the threat actor from assuming the role
+   - As a last resort, detach all policies from the role
+
+3. **Important:** Modifying the trust policy prevents new sessions from being created, but any currently valid credentials will continue to work until they expire. The session revocation approach (step 1) is the only way to immediately invalidate existing sessions.
+
+> ⚠️ Steps 1 and 2 will stop **all users** from using credentials obtained by assuming the role, including legitimate users and applications. Coordinate with the Application Owner before taking these actions.
+
+#### For all credential types — verify containment:
+
+After taking containment action, verify effectiveness by monitoring CloudTrail for the next 30 minutes for ongoing credential use. Filter by:
+- The specific `accessKeyId` (for long-term keys)
+- The IAM user name (for console access)
+- The role name and session name (for STS credentials)
+
+If activity continues from the same principal, the threat actor may have established persistence through additional credentials. Check for:
+- Additional access keys created on the same or other users
+- New IAM roles with trust policies allowing assumption from external accounts
+- Lambda functions or other compute resources with attached roles
+
+#### Lateral movement check:
+
+If the credential had permissions to assume roles in other accounts (cross-account access), check CloudTrail for `AssumeRole` calls to other accounts. If confirmed, repeat containment steps in those accounts.
+
+
+### 3.3 Document Containment Actions
+
+Record all containment actions taken, including timestamps, who performed them, and what was affected. This documentation supports the post-incident timeline (Part 5) and is important for any regulatory inquiries.
+
+- [ ] What credential was deactivated and when (timestamp, key ID or user, who performed the action)
+- [ ] What services or applications were impacted by the deactivation
+- [ ] Whether the deactivation was effective (did unauthorized activity stop?)
+- [ ] Any additional containment actions taken (deny policies, trust policy modifications, role session revocation)
+- [ ] Whether lateral movement to other accounts was identified and contained
+
+---
+
+## Part 4 — Eradicate & Recover
+
+## Part 4 — Eradicate
+
+> **CSF 2.0 Function:** Respond (Eradicate)
+> **Goal:** Identify the root cause of the compromise, remove any persistence mechanisms the threat actor created, and confirm the environment is clean. Eradication often uncovers additional compromised resources — if new findings emerge during this phase, return to Part 3 (Contain) for any newly identified credentials or access paths before continuing.
+
+### 4.1 Root Cause Identification
+
+> `[IR Lead]` owns this step. Document findings in the IR ticket in real time.
+
+Understanding how the credential was compromised is essential before issuing replacement credentials — if the root cause isn't resolved, new credentials will be compromised the same way.
+
+Common root causes for IAM credential compromise:
+
+- **Accidental exposure:** Access key committed to a public Git repository, pasted in a forum, included in a container image, or stored in plaintext in application configuration
+- **Phishing / social engineering:** User tricked into providing credentials or approving an MFA push notification
+- **Credential stuffing:** Console password reused from a breached third-party service (password reuse across sites)
+- **Malware / infostealer:** Credential harvested from a developer workstation by malware or a browser extension
+- **Overly permissive access:** The credential had far more permissions than needed, amplifying the scope of impact of the compromise
+- **Lack of rotation:** Long-lived access key never rotated, increasing the window of exposure
+
+Use the evidence documented in Part 2 to determine:
+- Where did the threat actor access from? (Geolocation, VPN/proxy, known malicious infrastructure)
+- When did unauthorized access begin? (First API call from the threat actor's IP)
+- How did the threat actor obtain the credential? (Check for public exposure, `GetSecretValue` access, phishing reports)
+
+### 4.2 Remove Credential-Based Persistence
+
+> `[IR Lead]` coordinates. `[Account Owner]` approves changes to production resources.
+
+When a credential is compromised, threat actors commonly create additional credentials or access paths that survive deactivation of the original credential. This section focuses on identifying and removing credential-based persistence. If the threat actor also created other resources (EC2 instances, Lambda functions, modified resource policies, etc.), refer to the eradication section of the relevant playbook for that resource type — for example, [IRP-EC2Compromise](IRP-EC2Compromise.md) (Coming Soon) for unauthorized compute resources.
+
+**Identify and remove unauthorized credentials:**
+
+- [ ] Additional access keys created on the compromised user (threat actors often create a second key before the first is deactivated)
+- [ ] Access keys created on *other* legitimate users during the incident window
+- [ ] Unauthorized IAM users created by the threat actor (check CloudTrail for `CreateUser` events)
+- [ ] Unauthorized IAM roles with trust policies allowing assumption from external accounts or from the compromised principal
+- [ ] Modified trust policies on existing roles (adding external principals the threat actor controls)
+- [ ] Unauthorized IAM policies attached to existing users or roles (escalating permissions beyond what was originally granted)
+- [ ] Modified permission boundaries or SCPs (weakening guardrails)
+
+**Rotate accessed secrets:**
+
+- [ ] Secrets accessed via Secrets Manager — rotate these immediately
+- [ ] SSM Parameter Store values accessed — update with new values
+- [ ] Any credentials stored in application configuration that the threat actor could have read (database passwords, API keys, etc.)
+
+> ⚠️ **If you discover additional compromised credentials or access paths during eradication, return to Part 3 (Contain) and deactivate those credentials before continuing.** Eradication is iterative — it's common to cycle between containment and eradication multiple times.
+
+> 📌 **Beyond credentials:** If CloudTrail shows the threat actor created compute resources, modified resource policies, or took other actions beyond credential manipulation, consult the relevant playbook for eradication guidance specific to those resource types. For a comprehensive reference of persistence techniques observed in AWS environments, see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
+
+### 4.3 Eradication Validation
+
+Before moving to recovery, confirm that the threat actor's access has been fully removed:
+
+- [ ] All persistence mechanisms identified in 4.2 have been removed
+- [ ] CloudTrail shows no continued unauthorized activity for at least 30 minutes after eradication actions
+- [ ] All accessed secrets and credentials have been rotated
+- [ ] No unauthorized resources remain in affected accounts
+- [ ] SCPs, resource policies, and trust policies have been reviewed and confirmed unmodified (or reverted)
+- [ ] GuardDuty shows no new findings related to the threat actor's activity
+
+> 🤖 **Automation opportunity:** AWS Config rules with auto-remediation can detect and alert on unauthorized IAM changes. Consider rules like `iam-user-no-policies-check`, `iam-root-access-key-check`, and custom rules for trust policy modifications.
+
+---
+
+## Part 4b — Recover
+
+> **CSF 2.0 Function:** Recover
+> **Goal:** Restore legitimate access, remove containment controls, and harden the environment against recurrence. Recovery should only proceed once eradication is validated — restoring access prematurely can re-expose the environment if persistence mechanisms were missed.
+
+### 4.4 Restore Legitimate Access
+
+> ⚠️ Before issuing new credentials, confirm the root cause (Section 4.1) is resolved. For example, if the credential was exposed because it was hardcoded in an EC2 instance's environment variables or user data, storing the new credential the same way will result in the same exposure.
+
+1. **Issue new credentials** for the legitimate user, appropriate to their use case:
+   - If programmatic access is needed: create a new access key (or better, migrate to IAM Roles Anywhere or Identity Center)
+   - If console access is needed: create a new login profile with a temporary password requiring reset on first use
+   - Re-enable or re-register MFA for the user
+
+2. **Remove containment controls** once you have confirmed eradication is complete:
+   - Remove the deny-all inline or managed policy that was applied during containment
+   - Remove the session revocation policy (if applied)
+   - Restore security group configurations (if network isolation was applied to associated resources)
+
+3. **Verify applications and services** that depended on the original credential are functioning with the new credential. Update any automation, CI/CD pipelines, or application configurations that referenced the old credential.
+
+### 4.5 Harden Against Recurrence
+
+Based on the root cause identified in Section 4.1, implement targeted hardening:
+
+- [ ] **Reduce permissions to least privilege** — use IAM Access Analyzer unused access findings to scope down policies to only what is needed
+- [ ] **Enforce MFA** for the affected user (and review org-wide MFA enforcement policy)
+- [ ] **Migrate away from long-term access keys** where possible — consider IAM Roles Anywhere, Identity Center, or instance/task roles
+- [ ] **Enable IMDSv2** requirement on EC2 instances if instance role credentials were involved
+- [ ] **Implement credential rotation policy** — 90-day maximum for any remaining long-term access keys
+- [ ] **Enable secret scanning** on all organization repositories (GitHub, GitLab, Bitbucket)
+- [ ] **Address the specific root cause:**
+  - If phishing: implement phishing-resistant MFA (FIDO2/WebAuthn), review security awareness training
+  - If public repo exposure: audit all repositories for secrets, implement pre-commit hooks
+  - If credential stuffing: enforce unique passwords, implement login anomaly detection
+  - If malware: ensure endpoint protection, consider workstation re-imaging before re-issuing credentials
+
+### 4.6 Recovery Validation
+
+- [ ] Legitimate user can authenticate and perform their normal duties
+- [ ] Applications and services that use the credential are functioning normally
+- [ ] No unauthorized resources remain in affected accounts
+- [ ] GuardDuty shows no new findings related to this incident
+- [ ] All containment controls have been removed
+- [ ] Monitoring and alerting confirmed operational for this principal
+- [ ] AWS Security Incident Response case updated (if applicable)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Capture what happened, when, and why — then use those findings to improve detection, response, and prevention for next time. Post-incident activity is not a one-time report; it generates action items that feed back into Part 1 (Prepare) for this and other playbooks.
+
+### 5.1 Timeline Reconstruction
+
+Build a complete timeline of the incident from initial compromise through recovery. This should be completed within 24–48 hours while events are fresh and CloudTrail data is readily queryable. A clear timeline supports post-incident review, regulatory inquiries, and future detection tuning.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| | Initial credential compromise (estimated) | Root cause analysis | Threat actor |
+| | First unauthorized API call | CloudTrail | Threat actor |
+| | Detection alert fired | GuardDuty / secret scanning | AWS / tooling |
+| | IR team notified | On-call alert | IR Lead |
+| | Credential deactivated | CloudTrail | IR team |
+| | Containment complete (deny policy applied) | CloudTrail | IR team |
+| | Eradication complete (persistence removed) | IR ticket | IR team |
+| | Recovery validated | IR ticket | IR Lead |
+
+**Key metrics:**
+
+These metrics help you measure response effectiveness over time and identify where investment would reduce future incident duration.
+
+| Metric | Value | Why It Matters |
+|---|---|---|
+| Time to Detect (TTD) | *Time from first unauthorized use to detection alert* | Measures detection coverage |
+| Time to Notify (TTN) | *Time from detection to IR team notified* | Measures alerting pipeline effectiveness |
+| Time to Contain (TTC) | *Time from notification to credential deactivated* | Measures response readiness |
+| Time to Recover (TTR) | *Time from containment to recovery validated* | Measures eradication thoroughness |
+| Total Incident Duration | | End-to-end impact window |
+| Affected Resources | *Count and type* | Blast radius |
+| Data Impact | *Confirmed / Suspected / None* | Drives regulatory notification |
+| Accounts Affected | *List account IDs* | Scope of cross-account spread |
+
+### 5.2 Post-Incident Review
+
+Conduct a blameless post-incident review within **5 business days** for P1/P2, **15 business days** for P3/P4. The goal is to identify systemic improvements, not assign blame. Include all stakeholders who participated in the response.
+
+Discussion questions specific to credential compromise:
+
+1. How was the credential exposed? Was this a preventable exposure with existing controls?
+2. Why did this credential have the permissions it had? Was least privilege applied?
+3. How long was the credential exposed before detection? What would have detected it sooner?
+4. Did the threat actor create persistence? Did we find all of it, or did we discover more later?
+5. Were there other credentials in the environment with similar exposure risk? (Audit all long-term access keys)
+6. Should this workload migrate from long-term keys to short-lived credentials (roles, Identity Center, Roles Anywhere)?
+7. Were our preparation steps (Part 1) adequate? Did we have the access, tools, and documentation we needed?
+8. What single change would most reduce the likelihood of this happening again?
+
+### 5.3 Detection Gap Analysis
+
+For each gap identified during the incident — whether a detection that didn't fire, an alert that wasn't actioned, or a blind spot in coverage — document the root cause and assign an owner to fix it.
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., Key exposed for 3 days before detection)* | *(No secret scanning on private repos)* | *(Enable secret scanning org-wide)* | | |
+| *(e.g., GuardDuty finding not actioned for 6 hours)* | *(Alert fatigue, finding lost in noise)* | *(Tune suppression rules, add PagerDuty integration)* | | |
+| *(e.g., Threat actor created persistence undetected)* | *(No alerting on CreateUser/CreateAccessKey)* | *(Add EventBridge rule for IAM mutation events)* | | |
+
+### 5.4 Playbook Update Checklist
+
+Use this incident to improve this playbook. Do not wait for the next scheduled review — update immediately while the gaps are clear.
+
+- [ ] Were triage questions (Part 2) sufficient? Add/remove as needed.
+- [ ] Were evidence documentation steps accurate for this scenario?
+- [ ] Were containment actions effective? Any unintended service disruption?
+- [ ] Were any new persistence mechanisms observed that aren't listed in Section 4.2?
+- [ ] Were automation opportunities identified? Add references to relevant sections.
+- [ ] Were severity criteria accurate? Did this incident get classified at the right level?
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+---
+
+## Appendix A — Investigation Resources
+
+For detailed Athena queries, GuardDuty CLI commands, and IAM Access Analyzer investigation commands relevant to credential compromise investigations, see:
+
+📁 [`resources/athena-queries-credential-compromise.sql`](resources/athena-queries-credential-compromise.sql)
+
+These queries cover:
+- All API activity for a specific access key
+- Source IP and user agent analysis (distinguishing legitimate vs. unauthorized usage)
+- Persistence detection (IAM mutations, role creation, policy changes)
+- Data access events (S3, DynamoDB, Secrets Manager)
+- Cross-account role assumptions
+- Error events (reconnaissance and permission testing indicators)
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal / Compliance]` owns this section during an active incident.
+
+See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obligation matrix.
+
+**Quick reference for credential compromise:**
+
+| Regulation | Trigger Condition | Timeframe |
+|---|---|---|
+| GDPR Art. 33 | Personal data confirmed accessed via compromised credential | 72 hours to supervisory authority |
+| HIPAA | PHI accessed via compromised credential | 60 days to HHS |
+| PCI-DSS 12.10 | Cardholder data environment accessed | Immediately to card brands |
+| SOC 2 CC7.3 | Any confirmed security incident in scope environment | Document for auditor |
+
+> ⚠️ The clock starts at **awareness**, not confirmation. If the compromised credential had access to regulated data and was used by a threat actor, assume notification is required and consult Legal immediately.
+
+---
+
+## Appendix C — Reference Links
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+- [AWS Security Incident Response Service](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Well-Architected Framework — Security Pillar: Incident Response](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/incident-response.html)
+- [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)
+- [IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html)
+- [Revoking IAM Role Temporary Security Credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html)
+- [Amazon GuardDuty IAM Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-iam.html)
+- [Amazon Detective Investigation Guide](https://docs.aws.amazon.com/detective/latest/userguide/investigation-about.html)
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/)
+- [GitHub Secret Scanning](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning)
+- [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/)
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | 2020-10-01 | AWS | Initial release |
+| 2.0 | 2026-06-18 | AWS CIRT | Full rewrite: NIST r3 alignment, template standardization, added IAM Access Analyzer, Identity Center references, AWS Security IR service, separated eradication and recovery phases, moved Athena queries to resources folder |

--- a/playbooks/IRP-CredCompromise.md
+++ b/playbooks/IRP-CredCompromise.md
@@ -77,7 +77,7 @@ The following services each contribute to your ability to detect, investigate, a
 - [ ] **S3 bucket for CloudTrail logs** has Object Lock or versioning enabled — protects audit trail from tampering by a threat actor who gains administrative access
 
 > 🤖 **Automation opportunity:** Deploy the [AWS Security Hub Automated Response and Remediation (SHARR)](https://aws.amazon.com/solutions/implementations/automated-security-response-on-aws/) solution to auto-remediate common IAM findings.
-
+>
 > 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
 ### 1.2 IAM & Access Prerequisites
@@ -186,6 +186,7 @@ For detailed Athena queries to investigate credential usage (source IP analysis,
 **Quick CloudTrail Console approach (no Athena required):**
 
 If Athena is not configured, you can investigate directly in the CloudTrail console:
+
 1. Navigate to **CloudTrail → Event history**
 2. Filter by **User name** = the IAM user under investigation
 3. Review source IPs — compare against known corporate IP ranges
@@ -222,7 +223,7 @@ For P1, P2, or P3 incidents, consider engaging AWS for support. AWS Support and 
 
 The goal of containment is to disable the credential so it can no longer be used, while understanding the impact of that action. Deactivating (not deleting or revoking) is preferred because it allows you to: (1) observe if legitimate services or users are impacted, (2) retain the credential ID for CloudTrail investigation, and (3) reverse the action quickly if the alert turns out to be a false positive.
 
-```
+```text
 Has the credential been confirmed used by a threat actor?
 │
 ├── YES (confirmed unauthorized use from unfamiliar source)
@@ -252,7 +253,6 @@ The containment approach depends on the type of credential involved. In all case
 2. **Monitor CloudTrail** for the next 30 minutes to confirm the credential is no longer being used. If you see continued activity from the same `accessKeyId`, the deactivation may not have propagated yet (allow a few minutes) or additional credentials may be in play.
 3. **Note any service disruption** — if legitimate applications were using this key, they will begin failing. Document what breaks so you can address it during recovery.
 
-
 #### If the credential is a console password:
 
 1. **Attach an explicit deny-all inline policy** to the IAM user. This immediately blocks all API and console actions while preserving the user account for investigation.
@@ -279,11 +279,13 @@ Short-term credentials obtained via AWS STS are associated with an IAM role and 
 #### For all credential types — verify containment:
 
 After taking containment action, verify effectiveness by monitoring CloudTrail for the next 30 minutes for ongoing credential use. Filter by:
+
 - The specific `accessKeyId` (for long-term keys)
 - The IAM user name (for console access)
 - The role name and session name (for STS credentials)
 
 If activity continues from the same principal, the threat actor may have established persistence through additional credentials. Check for:
+
 - Additional access keys created on the same or other users
 - New IAM roles with trust policies allowing assumption from external accounts
 - Lambda functions or other compute resources with attached roles
@@ -291,7 +293,6 @@ If activity continues from the same principal, the threat actor may have establi
 #### Lateral movement check:
 
 If the credential had permissions to assume roles in other accounts (cross-account access), check CloudTrail for `AssumeRole` calls to other accounts. If confirmed, repeat containment steps in those accounts.
-
 
 ### 3.3 Document Containment Actions
 
@@ -328,6 +329,7 @@ Common root causes for IAM credential compromise:
 - **Lack of rotation:** Long-lived access key never rotated, increasing the window of exposure
 
 Use the evidence documented in Part 2 to determine:
+
 - Where did the threat actor access from? (Geolocation, VPN/proxy, known malicious infrastructure)
 - When did unauthorized access begin? (First API call from the threat actor's IP)
 - How did the threat actor obtain the credential? (Check for public exposure, `GetSecretValue` access, phishing reports)
@@ -355,7 +357,7 @@ When a credential is compromised, threat actors commonly create additional crede
 - [ ] Any credentials stored in application configuration that the threat actor could have read (database passwords, API keys, etc.)
 
 > ⚠️ **If you discover additional compromised credentials or access paths during eradication, return to Part 3 (Contain) and deactivate those credentials before continuing.** Eradication is iterative — it's common to cycle between containment and eradication multiple times.
-
+>
 > 📌 **Beyond credentials:** If CloudTrail shows the threat actor created compute resources, modified resource policies, or took other actions beyond credential manipulation, consult the relevant playbook for eradication guidance specific to those resource types. For a comprehensive reference of persistence techniques observed in AWS environments, see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
 
 ### 4.3 Eradication Validation
@@ -503,6 +505,7 @@ For detailed Athena queries, GuardDuty CLI commands, and IAM Access Analyzer inv
 📁 [`resources/athena-queries-credential-compromise.sql`](resources/athena-queries-credential-compromise.sql)
 
 These queries cover:
+
 - All API activity for a specific access key
 - Source IP and user agent analysis (distinguishing legitimate vs. unauthorized usage)
 - Persistence detection (IAM mutations, role creation, policy changes)

--- a/playbooks/IRP-DataAccess.md
+++ b/playbooks/IRP-DataAccess.md
@@ -1,208 +1,601 @@
-# Incident Response Playbook Template
+# IRP-DataAccess: Unauthorized Data Access
 
-### Incident Type
+> **Playbook Version:** 2.1
+> **Last Reviewed:** 2026-06-18
+> **Status:** `Active`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-CredCompromise](IRP-CredCompromise.md) | [IRP-S3DataExfiltration](IRP-S3DataExfiltration.md) (Coming Soon) | [IRP-PersonalDataBreach](IRP-PersonalDataBreach.md) | [IRP-InsiderThreat](IRP-InsiderThreat.md) (Coming Soon)
 
-Unintended access to an Amazon Simple Storage Service (Amazon S3) bucket
-
-### Introduction
-
-This playbook is provided as a template to customers using AWS products and who are building their incident response capability.  You should customize this template to suit your particular needs, risks, available tools and work processes.
-
-Security and Compliance is a shared responsibility between you and AWS. AWS is responsible for “Security of the Cloud”, while you are responsible for “Security in the Cloud”. For more information on the shared responsibility model, [please review our documentation](https://aws.amazon.com/compliance/shared-responsibility-model/).
-
-You are responsible for making your own independent assessment of the information in this document. This document: (a) is for informational purposes only, (b) references current AWS product offerings and practices, which are subject to change without notice, and (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. This document is provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
-
-## Summary
-
-### This Playbook
- This playbook outlines response steps for unintended access to an Amazon Simple Storage Service (Amazon S3, or S3) bucket.  These steps are based on the [NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) that can be used to:
-
-* Gather evidence
-* Contain and then eradicate the incident
-* recover from the incident
-* Conduct post-incident activities, including post-mortem and feedback processes
-
-Interested readers may also refer to the [AWS Security Incident Response Guide]( https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) which contains additional resources.
-
-Once you have customized this playbook to meet your needs, it is important that you test the playbook (e.g., Game Days) and any automation (functional tests), update as necessary to achieve the desired results, and then publish to your knowledge management system and train all responders.
-
-Note that some of the incident response steps noted below may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing this runbook and testing it will help you to determine if additional costs will be incurred. You can use [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be.
-In reviewing this playbook, you will find steps that involve processes that you may not have in place today. Proactively preparing for incidents means you need the right resource configurations, tools and services in place that allow you to respond to an incident.
-The next section will provide a summary of this incident type, and then cover the five steps (parts 1 - 5) for handling unintended access to an S3 bucket.
-
-### This Incident Type
-By default, all S3 buckets are private and can be accessed only by users that are explicitly granted access.  Sometimes, customers will make changes to their bucket configuration to meet their requirements, or the requirements of their application. These changes (such as changes to a bucket policy, for example) may result in unintended access being granted to IAM principals or unauthenticated users. This playbook covers steps that can be used to deal with unintended access.
-
-## Incident Response Process
 ---
-### Part 1: Acquire, Preserve, Document Evidence
 
-1. You become aware that there has been a possible unintended data access to an Amazon S3 bucket. This information could come via different means, for example:
-    - An internal ticketing system (the sources of the ticket are varied and could include any of the means below)
-    - A message from a contractor or third-party service provider
-    - From an alert in one of your own monitoring systems either internal or external to AWS. For example, in AWS, this might include an AWS Config managed rule, AWS CloudTrail via Amazon EventBridge or Amazon CloudWatch Events and Amazon Simple Notification Service (Amazon SNS), via Amazon GuardDuty, AWS Security Hub or a similar service
-    - From a threat actor (for example, requesting a ransom or they will disclose data)
-    - From a security researcher
-    - Via an anonymous tip
-    - From a public news article in the press, on a blog or in the news
-2. At this point, you may not know if the issue is due to a mis-configured bucket, or a set of compromised credentials:
-    1. Use [AWS Identity and Access Management (IAM) Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html) to determine if any S3 buckets may have overly permissive configuration, giving unintended access to unauthorized principals
-    2. Use IAM Access Analyzer to determine if any IAM role trust policy provides unintended access to principals in the same or other AWS accounts
-    3. [Review CloudTrail logs](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/get-and-view-cloudtrail-log-files.html) to determine if recent (prior to the date on which the unintended access occurred, if known) changes had been made to bucket configuration, such as the bucket’s Block All Public Access settings, object ACLs, or bucket policies. You may choose to do this using a tool such as [Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html#tips-for-querying-cloudtrail-logs)
-    4. Review CloudTrail logs to determine if recent (prior to unintended access date, if known) changes have been made to IAM role trust policies
-3. If you are already aware of the S3 bucket(s) involved, Firstly move to **Part 2** to contain the incident. Once that is done, return here and then move on to step 5. If you have not established which bucket(s) are involved, continue to step 4.
-4. If you do not know which bucket is involved:
-    1. If you do not know which bucket is involved, but do know which data is involved:
-        1. Use internal tools that links that data to a bucket, such as checking a Configuration Management Database (CMDB)
-        2. Use the [S3 ls command](https://docs.aws.amazon.com/cli/latest/userguide/cli-services-s3-commands.html#using-s3-commands-listing-buckets) from the [AWS Command Line Interface (AWS CLI)](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) to list out the contents of your S3 bucket(s). For buckets with many objects, you can filter by specifying specific key prefixes in the ls command. This will be especially useful if you already know the data objects involved.
-        3. There are several common third-party tools that can also be used to search though files in Amazon S3
-        4. Query CloudTrail Data Event logs for one of the files in question, and determine the name of the bucket from the CloudTrail event. [You can do this using Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html#query-examples-cloudtrail-logs) This will also provide you the identity of the principal making the API call
-    2. If you do not know specifically which bucket or which data was involved, there are several options:
-        1. If you know the set of credentials involved, search CloudTrail **Data Events** using a tool such as Amazon Athena, filtering on that set of credentials and [s3.amazonaws.com](http://s3.amazonaws.com/) as the event source. If you do not have an Amazon Athena table already configured, you can [quickly set one up from the AWS CloudTrail console](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html#create-cloudtrail-table-ct).
-        2. Review [CloudTrail Insights](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/view-insights-events.html) (this must be enabled prior to the event) to determine if any insights have been generated that may relate to the time and date of the unintended access, and determine which resources were involved by drilling down into the events highlighted by the specific insight. This will also provide the user identity of the principal that accessed the object(s).
-        3. Simply go to the Amazon S3 console and review the “**Access**” column in the table listing all S3 buckets (under the **Buckets** menu). If the column lists a value of **Public** for a bucket, this means that unauthenticated users have access to objects in the bucket, by virtue of object ACLs or the bucket’s bucket policy. This is a useful approach for a single account.
-        4. If you want to check across multiple accounts in an AWS Organization, you can use Amazon Macie. Go to the Macie console and select **Summary** from the navigation menu. Review the percentage of buckets that are publicly accessible under the **Public** heading of the first table. Next, review the number of buckets that are shared with other AWS accounts by reviewing the information under the **Shared** heading of the first table.
-5. If the buckets are under your administrative control (either in an AWS account you control, or in an AWS account for which you have authorization and appropriate access, for example via an IAM Role), move ahead to **Part 2** to contain the incident, then return to this point and move on to step 7. If they are not under your administrative control, move on to step 6
-6. If you do not have administrative control of the S3 buckets involved, you will need to establish a communication channel with the provider/team/individual that does. This may involve opening a new case on the provider’s service platform, contacting their customer service, directly contacting your technical point of contact (PoC) in that organization, or something similar. Do this as a matter of urgency, as in Part 2, below, you will need to request that they take action to revoke the changes giving access.
-7. Confirm a ticket/case has been raised for the incident. If not, manually raise one.
-8. Determine if any user cases are already open for the bucket(s) that can be correlated to any notifications or data you already have in relation to the incident. Document any noted end-user impact/experience of the issue in the relevant ticket. These may include (but not be limited to):
-    1.  Files missing from the bucket
-    2. Unfamiliar new files in the bucket
-    3. Files that have had their access settings (such as ACLs) changed, in particular where those files have been made public
-    4. Modified bucket permissions, ACLs, Block Public Access settings (all less likely to be noted by regular users, but possible)
-9. In the case of automatically created tickets/cases, determine what internal alarms/metrics are currently indicating an issue (what caused the ticket to be created? - see 1a, above)
-10. Determine the application impacted (if any, this may be done quickly via Resource Tags, or by using your CMDB)
-11. Determine if there are any known events that could be causing service disruption (for example, an application change roll-out that is now resulting in the mishandling API interactions with the S3 bucket.) This could include but may not be limited to:
-    1. Writing incorrect files to the bucket
-    2. Incorrectly deleting files from the bucket
-    3. Modifying file or bucket permissions, ACLs, or Block Public Access settings
-12. Determine for the bucket and/or data in question, what is the [data classification](https://d1.awsstatic.com/whitepapers/compliance/AWS_Data_Classification.pdf) of the data that has been (or allegedly has been) accessed? The classification level may determine the incident response path taken, however the remainder of this playbook will assume that the classification of the data indicates some level of business impact (whether reputational, financial or other). This classification may be recorded in your CMDB or a specific data classification document.
-13. Incident Communications:
-    1. Identify stakeholder roles from the application entry in the Configuration Management Database (CMDB) entry for that application, or via the application’s risk register
-    2. Open a conference bridge war room for the incident
-    3. Notify other applicable internal stakeholders including legal personnel, technical teams and developers as required, and add them to the ticket and the war room, so they are updated as the ticket is updated
-14. External Communications (for the relevant team/people, not necessarily the first responder - most likely legal, PR, Technical/Account Managers, C-levels, etc.):
-    1. Identify customers that could have/are impacted by the incident
-    2. Identify customer data that could have been accessed as a result of the issue
-    3. Compile this information and *securely* distribute it to the relevant people (for example, using a corporate file share where permissions and access can be controlled)
-    4. Ensure your organizations legal counsel is informed and is included in status updates to internal stakeholders and especially in regards to external communications.
-    5. If there are regulations in your jurisdiction requiring reporting of such incidents, ensure the people in your organization responsible for notifying local or federal law enforcement agencies are also notified of the event. Consult your legal advisor and/or law enforcement for guidance on collecting and preserving the evidence and chain of custody.
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
 
-    Those teams/individuals will also likely identify public domain material (news articles, blog posts, tweets, etc.) that mention the incident and determine if/how to respond to these (some factors to consider include: Are the materials factually correct? How much information can be shared and at what time so as not to compromise any ongoing or future investigations? Are there any potential legal ramifications that need to be considered when responding? etc.). This is not a task for the first responder and should not distract that person from the immediate task of handling the technical aspects of the incident.
+---
 
-    6. There may not be regulations, but either open databases, government agencies or NGOs may track this type of activity. Your reporting may assist others.
+## Overview
 
-### Part 2: Contain the Incident
+Unauthorized data access occurs when a party — external threat actor or internal actor — accesses, copies, or exfiltrates data stored in AWS services without proper authorization. This includes bulk reads from S3 buckets, database queries extracting sensitive records, access to secrets or parameters, and download of backups or snapshots. The incident may result from compromised credentials, misconfigured resource policies, overly permissive access grants, or insider abuse. The severity depends on the sensitivity of the data accessed, the volume, and whether data left the AWS environment.
 
-By now, ideally, you should have confirmed whether there has been an unintended access incident and whether the incident relates to a set of leaked credentials, misconfigured bucket policies, modified object ACLs, or a combination of these. Firstly, if compromised credentials were involved, disable those credentials or revoke permissions associated with those credentials, thereby preventing any further API activity using the compromised credentials. Next, move on to bucket policies (if relevant). Finally, move on to Block Public Access settings.
+### Out of Scope
 
-1. For the **compromised credential** details obtained from reviewing CloudTrail logs in Part 1, disable those credentials if they are from AWS accounts under your administrative control
-    1. If they are long term IAM user credentials, [disable them using the IAM console or API](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)
-    2. If they are short term credentials obtained via AWS Security Token Service (AWS STS) they will be associated with an IAM role. There are a couple of options available to disable these:
-        1. [Revoke all current roles sessions](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html) (note that if the actor has the ability to obtain new credentials, this won’t solve the problem)
-        2. If the actor is able to obtain another set of credentials and the activity continues, it will then be necessary to remove all IAM policies attached to the role, modify the attached policies to block all access, or modify the role’s trust policy to prevent the actor from assuming the role. As the credentials will remain valid for the specified time duration once issued, it is important to note that **only** modifying the trust policy will allow any current valid credentials to continue to be used whilst still valid
-            **Note that the above actions will stop all users from using credentials obtained by assuming the role, including any legitimate users or applications**
-        3. If the role is attached to an EC2 instance, you will also need to review credentials related to the instance (for example, private/public key pairs used for SSH) to ensure that these have not also been compromised, allowing an actor to access an S3 bucket using the role credentials attached to the instance. Two key vectors:
-            1. A user obtains access to an EC2 instance using a set of credentials (private key) that allows them to SSH to the instance
-            2. The application on the EC2 instance is not correctly configured, and the instance/application form a reverse proxy, or behind certain types of web application firewalls, or has a role that is directly or indirectly internet-facing and a malicious user performs a Server-side Request Forgery (SSRF) with the goal of having the instance’s application simply repeat the request to S3 and return the output. Correct application configuration and EC2 features such as [IMDSv2]( https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/) can help mitigate these risks
-2. The compromised credentials should now be disabled. Verify this by checking the CloudTrail console for the next 30 minutes or so for ongoing credential use, whether by access key, IAM user, or Role.
-3. If the credentials used to obtain data are not under your administrative control, and the access was obtained using credentials (i.e., **not** unauthenticated access) the **bucket policy** is too permissive. IAM roles or users from other AWS accounts also need permissions to access a bucket in your account via the bucket policy. Therefore, it is necessary to modify the bucket’s bucket policy to restrict access to those principals:
-    1. From the bucket(s) identified in Part 1, review the bucket policies to determine which principals have access to the buckets for data plane and/or management plane operations:
-        1. **Do this first**: You will need to modify control plane access (for example, S3 PutBucketPolicy) to prevent unauthorized users from making changes to the bucket’s configuration (bucket policies, bucket ACL, bucket or account level Block Public Access settings)
-        2. You will need to modify data plane access Put*/Get* to prevent unauthorized users from accessing or modifying data that they should not have access to, for all applicable read and write operations
-        3. For specific objects of concern, identify any AWS accounts or predefined groups listed as having permission in the [object’s ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) (IAM users cannot be listed individually in an ACL). Another approach (if your permission model does not involve ACLs) is to modify the ACLs for all objects in the bucket to remove all other accounts or predefined groups and simply apply FULL_CONTROL to the bucket owner only (not the object owner - potentially from a different AWS account)
-4. If the issue is that the bucket allows public (unauthenticated) access to objects, either via ACLs, the bucket policy (“principal”: “*”) or a combination thereof, such settings will need to be modified:
-    1. the quickest way to remove this access is to modify the bucket’s **Block All Public Access** configuration. However note this will impact **all** objects in the bucket, not just the one(s) you are concerned with
-    2. For each bucket, in the Amazon S3 console, go to the object, select it and then click on **Permissions >> Access Control List**. There will be a note on the Access Control List button indicating public access. Check the **Everyone** radio button under the **Public access** row and then remove the checks in the boxes in the ACL’s settings. Finally, click **Save. **Note that this doesn’t modify an individual existing object’s ACL
-    3. For each object, in the Amazon S3 console, go to the object, select it and then click on **Permissions**. Under the **Public access** row, select the **Everyone** radio button and uncheck all the boxes in the resulting object ACL properties box and click **Save**. If many objects are involved, it will be quicker to use either the [AWS CLI or one of the AWS SDKs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html).
+This playbook does **not** cover:
 
-### Part 3: Eradicate the Incident
+- **Bulk S3 exfiltration with specific presigned URL or VPC endpoint abuse** — For dedicated S3 exfiltration patterns, see [IRP-S3DataExfiltration](IRP-S3DataExfiltration.md). (Coming Soon)
+- **Credential compromise as the root cause** — If the data access resulted from stolen credentials, start with [IRP-CredCompromise](IRP-CredCompromise.md) for containment, then return here for data impact assessment.
+- **Personal data breach regulatory response** — If personal/regulated data is confirmed accessed, cross-reference [IRP-PersonalDataBreach](IRP-PersonalDataBreach.md) for notification obligations.
+- **Insider threat investigation** — If the accessor is an authorized user acting outside their role, see [IRP-InsiderThreat](IRP-InsiderThreat.md). (Coming Soon)
 
-Key components of the eradication process include the following:
+### Applicable Finding Types
 
-1. Mitigate any vulnerabilities that were exploited
-2. Rotate compromised passwords/credentials
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon GuardDuty | `Exfiltration:S3/MaliciousIPCaller` | HIGH |
+| Amazon GuardDuty | `Exfiltration:S3/AnomalousBehavior` | HIGH |
+| Amazon GuardDuty | `Discovery:S3/MaliciousIPCaller.Custom` | MEDIUM |
+| Amazon GuardDuty | `UnauthorizedAccess:S3/MaliciousIPCaller.Custom` | HIGH |
+| Amazon GuardDuty | `Policy:S3/BucketBlockPublicAccessDisabled` | LOW |
+| Amazon GuardDuty | `Policy:S3/BucketAnonymousAccessGranted` | HIGH |
+| Amazon Macie | Sensitive data discovery findings (PII, credentials, financial) | HIGH |
+| Amazon Macie | Policy findings (public bucket, unencrypted, shared externally) | MEDIUM |
+| AWS Security Hub | S3 public access findings | HIGH |
+| CloudTrail | Unusual volume of `GetObject`, `GetItem`, `Query`, `Scan` events | — |
+| CloudTrail | `GetSecretValue`, `GetParameter` from unexpected principals | — |
+| CloudTrail | S3 data events from unfamiliar IPs or cross-account roles | — |
+| AWS Config | `s3-bucket-public-read-prohibited`, `s3-bucket-public-write-prohibited` | HIGH |
+| VPC Flow Logs | Large outbound data transfers to external IPs | — |
 
-Most of the steps in this section are taken from the [security best practices for Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html). Check back with that document frequently for updates.
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
 
+### Severity Classification
 
-1. Eradicate any attack vectors related to systems writing to or reading from the S3 bucket(s). As per **Part 2**, if an actor has gained access to systems that are writing to a bucket, the actor  could now effectively use the instance’s credentials (via the AWS CLI or AWS SDK) on an application instance, for example, to read data from the bucket:
-    1. [Configure IMDSv2](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/) on all application instances/role holding instances
-    2. [Rotate SSH credentials](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) for EC2 Linux. Consider the following steps:
-      1. Determine which instances are using that key pair: `aws ec2 describe-instances --query "Reservations[*].Instances[].[KeyName, InstanceId]"` (Windows CMD example)
-        1. Decide on the following:
-            - If the instances should be terminated
-                1. Establish if the instances can be terminated without impacting your application (for example, using your CMDB, your EC2 instance tags, etc.)
-            - Is it sufficient to rotate an instance's user credentials by:
-                - Modifying the contents of the `authorized_keys` file; or,
-                - Removing the user; and/or,
-                - Remove/modify the user's .ssh directory
-                - On Windows, modify the allowed RDP users via `Remote Desktop Users`.
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | Confirmed exfiltration of sensitive/regulated data outside AWS, or public exposure of customer data confirmed |
+| **P2 — High** | Confirmed unauthorized data access (reads confirmed), data sensitivity unclear or data hasn't left AWS yet |
+| **P3 — Medium** | Anomalous data access patterns detected, no confirmed unauthorized access yet |
+| **P4 — Low** | Misconfiguration found (public bucket, overly permissive policy) with no evidence of exploitation |
 
-            [At scale, use AWS Systems Manager to manage instance configuration](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html).
-      2. If the instances have been launched using some kind of scaling mechanism:
-        1. Determine if you have any [Launch Configurations]( https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchConfiguration.html) referencing the key pair. If so, create either a new Launch Configuration referencing the new key pair and, associate it to the required resources, such as EC2 Auto Scaling Groups, or instead move on to step 4 and create a launch Template, giving you all the current features for EC2 Auto Scaling
-        2. Determine if you have any existing [Launch Templates]( https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html) for EC2 referencing the existing key pair. If so, delete that template, follow the steps below and then create a new template once a new key pair has been created.
-        5. Delete the key pair from your EC2 console
-        6. Terminate the instances
-        7. Create a new key pair in AWS and issue it to any required personnel
-        8. Launch instances using the new key pair
-        9. Update user passwords for domain or local users using Microsoft Windows Remote Desktop Protocol (RDP) and verify users in the Remote Desktop Users group within Windows and/or Group Policy (for example, if you are adding Active Directory Global Security Groups to the Remote Desktop Users group on local operating systems, a fairly common Group Policy task)
-    3. [Revoke credentials for all existing role sessions]( https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_revoke-sessions.html). This will block access to AWS APIs from the EC2 instance until that instance obtains a new set of role credentials. The instance can obtain new role credentials by waiting until the existing set of credentials are rotated automatically, or by detaching and re-attaching the same role to the EC2 instance. If there are concerns that a threat actor has remote access to the instance (for example, by SSH or RDP), per step 2 in this section, terminate the existing EC2 instance and create a new one after revoking existing sessions. Note that if the instance is accessed using [Key Pairs defined in EC2]( https://docs.aws.amazon.com/cli/latest/userguide/cli-services-ec2-keypairs.html) you should determine if other instances are using the same key pairs and take appropriate action to prevent the threat actor also accessing those instances. Such steps might include:
+---
 
-2. Mitigate vulnerabilities related to your service configurations. For example, with S3, determine which configuration items need to be updated:
-    1. Return modified object ACLs to their secure settings, removing unauthenticated access permissions
-    2. Implement least privilege in bucket policies
-    3. Ensure only appropriate principals have permission to perform data or control plane operations on the bucket
-    4. Ensure IAM policies are appropriately scoped and if necessary, [Permission Boundaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) and/or [Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html) have been deployed appropriately
-    5. Encrypt data at rest using [Amazon S3 Server Side Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) - this protects the data at rest, and means that principals must have permissions in **both **S3 and AWS Key Management Service (AWS KMS) (the AWS KMS Customer Master Key (CMK) key policy) to access the data
-    6. [Enable versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html) in S3 to enable data recovery, and consider:
-    7. [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html) to prevent the deletion of critical data
+## Part 1 — Prepare
 
-3. If credential compromise was involved:
-    1. Flag for review the process for handling user credentials during Move/Add/Change (MAC) procedures for the post-incident activity
-    2. The compromised credentials should have been disabled in Part 2, you may now consider issuing new credentials to impacted users
-    3. Close down/remove user accounts or roles if they are not valid accounts/roles (or IAM IdPs, AWS Single Sign-On (AWS SSO) instances, etc.)
-    4. Enable [MFA Delete for S3]( https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeletingObjects.html#DeletingObjectsfromanMFA-EnabledBucket), which means users must provide a valid MFA token along with the request to delete any versioned object in the bucket. This requires also enabling S3 Versioning
-    5. If you have objects that need to be public, rather than setting the ACL so that the object is world-readable, consider using an S3 pre-signed URL with a suitable expiry time and have your application pass that to the unauthenticated user to allow them to access the object.
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
 
-### Part 4: Recover from the Incident
+### 1.1 Recommended AWS Service Configurations
 
-The next step is to determine if the incident has been mitigated, or if additional tuning is needed to eradicate it. This includes reviewing pre- and post-mitigation logs to:
+The following services each contribute to your ability to detect, investigate, and respond to unauthorized data access. None are strictly required, but each addresses a specific gap in visibility — the more you have enabled, the faster you can detect anomalous access and the more complete your forensic picture will be during an investigation.
 
-* Determine the impact of the mitigations already performed
-* Identify any other attack signatures to attempt to eradicate or further mitigate the incident
+- [ ] **Amazon GuardDuty** enabled with S3 protection activated — provides continuous threat detection for S3 exfiltration patterns, anomalous access, and malicious IP callers
+- [ ] **Amazon Macie** enabled with automated sensitive data discovery on critical buckets — identifies where sensitive data lives and alerts on policy violations or unexpected access patterns
+- [ ] **AWS CloudTrail** enabled with **S3 data events** for sensitive buckets (GetObject, PutObject, DeleteObject) — without data events, individual object-level access is invisible to investigation
+- [ ] **AWS CloudTrail** enabled with **DynamoDB data events** for sensitive tables (if applicable) — captures individual item-level reads and writes
+- [ ] **AWS Config** enabled with S3-related rules (`s3-bucket-public-read-prohibited`, `s3-bucket-ssl-requests-only`, `s3-bucket-logging-enabled`) — provides continuous compliance assessment and drift detection
+- [ ] **S3 server access logging** enabled on all sensitive buckets — captures access details (including presigned URL usage) that CloudTrail data events may not cover
+- [ ] **VPC Flow Logs** enabled — detects large outbound data transfers that may indicate exfiltration
+- [ ] **Amazon Detective** enabled — provides graph-based investigation of access patterns, reducing time to scope impact
+- [ ] **S3 Block Public Access** enabled at the account level — prevents accidental public exposure of any bucket in the account
+- [ ] **AWS Security Lake** enabled — centralizes security data across services for cross-service correlation and analysis
 
-Once this has been completed, it will likely be necessary to restore any lost or corrupted data.
+> 🤖 **Automation opportunity:** Use Macie automated sensitive data discovery to continuously classify data in S3 buckets. Configure EventBridge rules to alert on Macie HIGH findings.
 
-Restore lost or modified data:
+> 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
-1. If you have [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html), [restore an earlier version of the object](https://docs.aws.amazon.com/AmazonS3/latest/dev/RestoringPreviousVersions.html) to replace the modified object. If the object has been deleted using a simple delete command (without specifying a version ID for the object, it will now have a [delete marker](https://docs.aws.amazon.com/AmazonS3/latest/dev/DeleteMarker.html) in place of the object. you can [delete the delete marker](https://docs.aws.amazon.com/AmazonS3/latest/dev/RemDelMarker.html) to recover the object
-2. If the object was deleted and the delete command specified an object Version ID, that version of the object will be permanently deleted. You will need to establish if previous versions of the object still exist, or of the object can be retrieved from another location (see below steps)
-3. If you move data to other S3 storage classes (S3 IA, Amazon Simple Storage Service Glacier, etc.) as part of a back-up or archival process, determine if the files still exist in that storage class and retrieve them (remember that files *can be deleted* from other storage classes). [Lifecycle policies](https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-transition-general-considerations.html) are used to move objects between storage classes
-4. If you are using S3 Cross Region Replication (CRR) restore the data from the target bucket to the source bucket as necessary
-5. If none of the previous actions allow you to restore the deleted or modified data, you will need to determine if the data is retrievable from another source (such as an on-premise system or an S3 bucket in a different account
+### 1.2 IAM & Access Prerequisites
 
-From the logs obtained in PART 1, review those obtained at the time of the initial investigation. Now that mitigations are in place, you need to go back and obtain those metrics and logs again, and compare them to the incident metrics and logs obtained earlier.
+Effective incident response depends on having the right access available *before* an incident occurs. Provisioning break-glass access during an active data exfiltration wastes time and introduces risk of error under pressure. The following recommendations align with [SEC10-BP05 Pre-provision access](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_provision_access.html) from the AWS Well-Architected Framework.
 
-If data plane activity has returned to pre-attack levels and the logs show no further evidence of malicious use, the attack has been mitigated (at least for now). Continue to monitor the service post-attack; if suspicious data plane activity reoccurs, take the following steps:
+- [ ] **Break-glass IAM role** with permissions to: query CloudTrail, list/get S3 objects, describe bucket policies, query Macie findings, and modify bucket policies — pre-tested and documented
+- [ ] **IR team members can assume the break-glass role** with MFA from a trusted (non-production) account — validate this works at least quarterly
+- [ ] **Data classification inventory** exists (which buckets/tables contain sensitive data) — you cannot assess impact without knowing what the data is
+- [ ] **S3 Access Grants inventory** documented (who has access to what via Access Grants) — provides baseline for detecting unauthorized grants
+- [ ] **Forensic S3 bucket** available with Object Lock enabled — optional but recommended for preserving evidence copies with tamper protection
+- [ ] **Access to AWS Security Incident Response console** confirmed, if subscribed — verify case creation workflow before you need it
 
-1.  Return to Part 1 and follow those steps again
-2. Review logs and related data to determine if you have correctly identified the attack vector, or if the actor has changed the vector in response to the mitigation
+### 1.3 Communication & Escalation
 
-### Part 5: Post-Incident Activity
+Clear communication paths reduce confusion during high-pressure incidents. Define who needs to be involved, at what severity threshold, and through which channel *before* you need them. The goal is to avoid spending incident time figuring out who to call.
 
-This “sharpen the saw” activity helps teams to assess their response to the actual incident, determine what worked and what didn’t, update the process based on that information and record these findings.
+> 📋 Do not include names in this playbook. Use roles only. Maintain a separate, access-controlled contact list (e.g., internal wiki, sealed envelope, or secure document) with current names, phone numbers, and escalation preferences.
 
+| Role | Responsibility | When to Engage |
+|---|---|---|
+| IR Lead | Overall incident coordination, status updates, decision authority for containment actions | All severity levels — first notified |
+| Data Owner | Classify data sensitivity, authorize access restrictions, confirm legitimate access patterns | P1–P3, or when data sensitivity is unclear |
+| Account Owner | Business context, authorization for containment actions that may impact services | P1–P3, or when containment may disrupt services |
+| Legal / Compliance | Regulatory notification assessment, evidence hold | P1–P2, or when regulated data may have been accessed |
+| Privacy Officer | Personal data impact assessment (if applicable) | When personal/health/financial data is confirmed accessed |
+| AWS CIRT | Technical assistance with scoping, containment guidance, help determining if access was unauthorized | P1–P2 via AWS Support case (any support plan) or Security Incident Response service (if subscribed) |
 
-1. Review how the incident was handled, as well as the incident handling process generally, with key stakeholders identified in Part 1.
-2. Document lessons learned, including attack vector(s) mitigation(s), misconfiguration, etc.
-3. Store the artifacts from this process with the application information in the CMDB entry for the application and also in the CMDB entry for the S3 bucket and the data leak incident response process.
-4. Update risk documents based on any newly discovered threat/vulnerability combinations that were discovered as a result of lessons learned
-5. If new application or infrastructure configuration is required to mitigate any newly identified risks, conduct these change activities and update application and component configuration in the CMDB
-6. Ask the following questions and assign people to resolve any issues that come up as a result:
-    1. What information would have helped me respond to this incident more swiftly?
-    2. What detection would have alerted me to the issue sooner?
-    3. What configuration (technical or process) would have prevented this data being exposed in this way?
-    4. What automation, tooling or access would have made it easier to investigate the root cause?
-7. For any actions that are raised as the result of parts 3, 4 and 5, assign those actions and follow up to ensure they are completed
+**Escalation path:**
+
+1. **Detection:** Automated alert (Macie, GuardDuty, Config, SIEM) or human report triggers initial notification.
+2. **Triage (IR Lead, < 15 min):** IR Lead assesses severity using [Section 2.3](#23-severity-determination). Determines if the access is ongoing and whether it is confirmed unauthorized.
+3. **Severity-based escalation:**
+   - **P1/P2:** IR Lead notifies Data Owner and Legal/Compliance immediately. Opens AWS Support case (severity: Critical) requesting CIRT assistance. If AWS Security Incident Response service is enabled, creates a case there instead.
+   - **P3/P4:** IR Lead manages internally with Data Owner. Escalates to P2 if investigation confirms unauthorized access to sensitive data.
+4. **Status updates:** IR Lead provides updates to stakeholders every 30 minutes (P1), every 2 hours (P2), or at key milestones (P3/P4).
+
+> 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — recommends identifying and documenting internal and external resources and contact information ahead of time.
+
+### 1.4 Game Day Guidance
+
+Practicing incident response before a real incident occurs builds muscle memory, identifies gaps in tooling and access, and validates that escalation paths work. Data access scenarios are particularly important to rehearse because they often involve regulatory notification decisions under time pressure.
+
+Recommended testing cadence: **Semi-annually** (P1-capable scenario with regulatory implications).
+
+Suggested tabletop scenario:
+> *"Amazon Macie has flagged a sensitive data discovery finding: a production S3 bucket containing customer PII has been accessed 4,000 times in the last hour from an IAM role in a different account. The role belongs to a third-party vendor with a data processing agreement. Normal access volume for this role is ~50 requests/hour."*
+
+**Practice resources (no paid service or support plan required):**
+
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/) — free, hands-on workshops covering credential compromise, S3 ransomware, and more. Deployable in any AWS account.
+- [AWS Incident Response Playbooks Workshop](https://github.com/aws-samples/aws-incident-response-playbooks-workshop/) — open-source workshop for building and testing IR playbooks.
+- [AWS Security Workshops catalog](https://workshops.aws/categories/Security) — broader collection of security-focused hands-on labs.
+
+> 📖 **Reference:** [SEC10-BP04 Develop and test security incident response playbooks](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_playbooks.html) — recommends creating and regularly testing playbooks to verify response processes.
+
+---
+
+## Part 2 — Detect & Analyse
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyse)
+> **Goal:** Determine whether unauthorized data access has occurred, scope its impact, and document the evidence needed to support containment and recovery decisions.
+
+### 2.1 Initial Triage Questions
+
+Not every alert is a confirmed incident. The purpose of triage is to quickly determine whether you are dealing with confirmed unauthorized access, a potential issue requiring investigation, or a false positive that can be closed. Answer these questions to establish scope and urgency — each should take less than 2 minutes.
+
+- [ ] What data store was accessed? (S3, DynamoDB, RDS, Secrets Manager, Parameter Store, Redshift, other)
+- [ ] What is the data classification? (Public, internal, confidential, restricted/regulated)
+- [ ] Who accessed it? (Known principal, unknown principal, cross-account, anonymous)
+- [ ] Was the access authorized? (Check IAM policies, resource policies, Access Grants, Lake Formation permissions)
+- [ ] Is the access confirmed unauthorized, or could it be legitimate but unusual? (New integration, batch job, vendor access within agreement)
+- [ ] What volume of data was accessed? (Number of objects/records, total bytes)
+- [ ] Did data leave the AWS environment? (Check VPC Flow Logs, CloudTrail for cross-region copies, external transfers)
+- [ ] Is the access ongoing or historical? (Is the accessor still active?)
+- [ ] Does the data include personal data, health data, financial data, or credentials?
+
+**If regulated data confirmed accessed by unauthorized party → P1 immediately. Notify Legal.**
+**If the activity is anomalous but could be legitimate → investigate further before containment (avoid unnecessary disruption).**
+
+### 2.2 Evidence Documentation
+
+Whether the activity is confirmed malicious or still under investigation, document the current state of the affected data stores and access patterns. For data access scenarios, the primary evidence sources are CloudTrail (with S3 data events), S3 server access logs, and Macie findings. The priority here is *documenting what you observe* rather than copying logs to a separate location.
+
+> 📌 **Note on evidence storage:** CloudTrail logs and S3 server access logs persist in their configured destinations — they don't disappear if you don't copy them immediately. If you have a dedicated forensic S3 bucket with Object Lock, export findings there for tamper protection. If you don't, that's fine — the primary logs, findings in the console, and notes in your IR ticket are sufficient for most investigations.
+
+> ⚠️ **Do not modify bucket policies or revoke access before documenting current state.** Capture the current configuration first.
+
+**Document the following:**
+
+| What to Document | How | Notes |
+|---|---|---|
+| Current bucket policy | `aws s3api get-bucket-policy --bucket BUCKET` | Capture before modification |
+| Current bucket ACL | `aws s3api get-bucket-acl --bucket BUCKET` | Identify unexpected grantees |
+| S3 Access Grants | `aws s3control list-access-grants --account-id ACCOUNT` | Identify unexpected grants |
+| Lake Formation permissions | `aws lakeformation list-permissions` | If applicable |
+| Macie findings | Macie console → Export findings | Data sensitivity classification |
+| GuardDuty findings | GuardDuty console or `aws guardduty get-findings` | Threat detection context |
+| VPC Flow Logs (if applicable) | CloudWatch Logs / S3 | Large outbound transfers |
+| S3 server access logs | Copy from logging bucket for affected time window | Presigned URL and anonymous access |
+
+**CloudTrail / Athena investigation queries:**
+
+For detailed Athena queries to investigate data access (bulk read detection, principal analysis, data staging, secrets access, policy changes), see:
+
+📁 [`resources/athena-queries-data-access.sql`](resources/athena-queries-data-access.sql)
+
+**Quick CloudTrail Console approach (no Athena required):**
+
+If Athena is not configured, you can investigate directly in the CloudTrail console:
+1. Navigate to **CloudTrail → Event history**
+2. Filter by **Event source** = `s3.amazonaws.com` and **Event name** = `GetObject`
+3. Review source IPs and principals — compare against known legitimate access patterns
+4. Look for volume anomalies — many `GetObject` calls in a short window from one principal
+5. Check for policy modification events (`PutBucketPolicy`, `DeleteBucketPublicAccessBlock`)
+6. Filter by **Event source** = `secretsmanager.amazonaws.com` to check for secrets access
+
+> 📌 CloudTrail Event history only shows management events by default. S3 data events (GetObject, PutObject) require a trail configured with data event logging.
+
+### 2.3 Severity Determination
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Regulated/sensitive data confirmed exfiltrated outside AWS | P1 |
+| Sensitive data confirmed accessed, exfiltration unclear | P2 |
+| Public exposure of data confirmed (misconfigured bucket) | P2 |
+| Anomalous access patterns, data sensitivity unclear | P3 |
+| Misconfiguration found, no evidence of exploitation | P4 |
+
+### 2.4 Getting Help from AWS
+
+For P1, P2, or P3 incidents, consider engaging AWS for support. AWS Support and AWS CIRT can help you determine whether access was truly unauthorized, assist with scoping the data impact, and advise on containment approaches — you do not need to be certain of a compromise before reaching out.
+
+- **AWS Security Incident Response service** (if enabled): Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose **Active Security Incident** for urgent support or **Investigations and Inquiries** for log analysis and secondary confirmation of findings.
+- **AWS Support** (any support plan): Open a support case requesting assistance from the AWS Customer Incident Response Team (CIRT). Include the finding ID(s), the affected data stores, and a summary of the anomalous access you have observed.
+
+> 📌 You do not need the Security Incident Response service to get help from experts. All AWS customers can request CIRT assistance through a support case, regardless of support plan level. For P3 (anomalous access patterns, not yet confirmed), AWS CIRT can help you determine whether the activity is unauthorized or legitimate.
+
+> 🤖 **Automation opportunity:** EventBridge rule on Macie HIGH-severity findings → auto-create Security Incident Response case.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Stop further unauthorized data access and prevent data from leaving the environment, while minimizing disruption to legitimate users and services. Containment should be deliberate — restrict access rather than delete resources, so you preserve evidence and can reverse actions if the alert turns out to be a false positive.
+
+### 3.1 Containment Decision
+
+The goal of containment is to close the access path so data can no longer be reached by the threat actor, while understanding the impact of that action on legitimate users. Restricting (not deleting) is preferred because it allows you to: (1) observe if legitimate services are impacted, (2) retain the configuration for investigation, and (3) reverse the action if needed.
+
+```
+Is data actively being exfiltrated RIGHT NOW?
+│
+├── YES (ongoing bulk reads, active transfer)
+│     └── Proceed to 3.2 immediately — block access
+│
+├── PUBLIC EXPOSURE (bucket/resource is publicly accessible)
+│     └── Proceed to 3.2 immediately — remove public access
+│
+└── HISTORICAL (access occurred in the past, not ongoing)
+      └── Assess: Is the access path still open?
+            ├── YES → Proceed to 3.2 (close the path)
+            └── NO (credential already revoked, policy already fixed) → Skip to Part 4
+```
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates. `[Data Owner]` authorizes access restrictions. `[Account Owner]` authorizes service-impacting changes.
+
+**Step 1: Identify the access path**
+
+Determine HOW the unauthorized access is occurring:
+
+| Access Path | Containment Approach |
+|---|---|
+| Compromised IAM credential | Revoke credential (see [IRP-CredCompromise](IRP-CredCompromise.md)) |
+| Overly permissive bucket policy | Restrict bucket policy to deny the unauthorized principal |
+| Public access (ACL or Block Public Access disabled) | Enable Block Public Access at the bucket level |
+| Cross-account role with excessive permissions | Modify trust policy or attached permissions to block the unauthorized account |
+| S3 Access Grant misconfiguration | Revoke the specific grant |
+| Lake Formation permission grant | Revoke the specific permission |
+| VPC endpoint policy too broad | Restrict endpoint policy to specific buckets and principals |
+| Presigned URL abuse | Cannot revoke individual URLs — rotate the signing credential |
+
+**Step 2: Block unauthorized access to S3**
+
+Based on the identified access path, take the appropriate containment action:
+
+- **If public exposure:** Enable S3 Block Public Access on the affected bucket. This immediately blocks all public access regardless of bucket policy or ACL settings.
+- **If unauthorized principal:** Add an explicit deny statement to the bucket policy for the unauthorized principal (account, role, or user ARN). Use `"Effect": "Deny"` with `"Action": "s3:*"` on the bucket and all objects.
+- **If VPC endpoint is the path:** Modify the VPC endpoint policy to restrict which principals and buckets are accessible through the endpoint.
+
+> 📌 An explicit deny in a bucket policy overrides any allow. This is the fastest way to block a specific principal without disrupting other legitimate access.
+
+**Step 3: Block unauthorized access to DynamoDB / other data stores**
+
+For data stores that don't support resource-based policies (DynamoDB, Secrets Manager, SSM Parameter Store), containment must be applied at the IAM level:
+
+- Attach an explicit deny inline policy to the unauthorized principal, blocking access to the affected data services (`dynamodb:*`, `s3:*`, `secretsmanager:*`, `ssm:GetParameter*`).
+- If the unauthorized principal is in a different account, modify the trust policy on any roles they were using, or apply an SCP to the affected account.
+
+**Step 4: Revoke S3 Access Grants (if applicable)**
+
+If unauthorized access was via S3 Access Grants, list the grants scoped to the affected bucket and delete the unauthorized grant using the S3 Access Grants API.
+
+**Step 5: Revoke Lake Formation permissions (if applicable)**
+
+If unauthorized access was via Lake Formation permissions, revoke the specific permission grant for the unauthorized principal on the affected database/table.
+
+> 🤖 **Automation opportunity:** Security Hub custom action → Lambda function that automatically enables S3 Block Public Access on flagged buckets.
+
+### 3.3 Document Containment Actions
+
+Record all containment actions taken, including timestamps, who performed them, and what was affected. This documentation supports the post-incident timeline (Part 5) and is important for any regulatory inquiries.
+
+- [ ] What access path was blocked and when (timestamp, resource affected, who performed the action)
+- [ ] What the bucket policy / ACL / grant looked like *before* modification (captured in Section 2.2)
+- [ ] What services or applications were impacted by the access restriction
+- [ ] Whether the containment was effective (did unauthorized activity stop?)
+- [ ] Any additional containment actions taken (VPC endpoint changes, SCP application, credential revocation)
+- [ ] Whether the threat actor had access to other data stores that also need containment
+
+---
+
+## Part 4 — Eradicate
+
+> **CSF 2.0 Function:** Respond (Eradicate)
+> **Goal:** Identify the root cause of the unauthorized access, remove any persistence mechanisms, and confirm the environment is clean. Eradication often uncovers additional exposed data stores — if new findings emerge during this phase, return to Part 3 (Contain) for any newly identified access paths before continuing.
+
+### 4.1 Root Cause Identification
+
+> `[IR Lead]` owns this step. Document findings in the IR ticket in real time.
+
+Understanding how the unauthorized access occurred is essential before restoring access — if the root cause isn't resolved, the same exposure will recur.
+
+Common root causes for unauthorized data access:
+
+- **Misconfigured resource policy:** Bucket policy or ACL granting broader access than intended (wildcard principals, missing conditions)
+- **Overly permissive IAM policy:** Principal had access to data beyond their role requirements
+- **Credential compromise:** Threat actor used stolen credentials to access data (see [IRP-CredCompromise](IRP-CredCompromise.md))
+- **Cross-account trust misconfiguration:** Role trust policy allowed assumption from unintended accounts
+- **S3 Access Grants misconfiguration:** Grant scope too broad or granted to wrong identity
+- **Lake Formation permission drift:** Permissions accumulated over time without review
+- **VPC endpoint policy too permissive:** Allowed any principal in the VPC to access any S3 bucket
+- **Presigned URL leakage:** Long-lived presigned URLs shared beyond intended recipients
+
+### 4.2 Eradication Actions
+
+This section focuses on data-access-specific persistence — policy changes, grants, and endpoint configurations that would allow re-access even after initial containment. If the root cause is credential compromise, address credential-based persistence using [IRP-CredCompromise](IRP-CredCompromise.md) eradication steps. For a comprehensive reference of persistence techniques observed in AWS environments, see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
+
+**Step 1: Fix the root cause**
+
+| Root Cause | Eradication Action |
+|---|---|
+| Public bucket policy | Rewrite policy with least-privilege; enable Block Public Access at account level |
+| Overly permissive IAM | Use IAM Access Analyzer recommendations to scope down permissions |
+| Cross-account trust | Remove unauthorized principals from trust policy |
+| Access Grants | Delete or scope down the grant |
+| Lake Formation | Revoke excessive permissions, implement column-level security |
+| VPC endpoint | Restrict endpoint policy to specific buckets and principals |
+| Presigned URL | Rotate the signing credential; reduce URL expiry to minimum needed |
+
+**Step 2: Remove data-access-specific persistence**
+
+Check for changes the threat actor may have made to maintain access:
+
+- [ ] Bucket policy modifications (new principals added, conditions removed)
+- [ ] S3 Access Grants created by the threat actor
+- [ ] Lake Formation permissions granted by the threat actor
+- [ ] VPC endpoint policy modifications
+- [ ] Cross-account role trust policy modifications (adding external principals)
+- [ ] S3 replication rules added (replicating data to threat-actor-controlled buckets)
+- [ ] S3 event notifications added (Lambda triggers on object creation for data exfiltration)
+- [ ] Lifecycle rules modified (accelerating object deletion to cover tracks)
+
+**Step 3: Rotate any secrets or credentials that were accessed**
+
+- [ ] Secrets Manager secrets that were read → rotate immediately
+- [ ] SSM Parameter Store values that were read → update with new values
+- [ ] Database credentials that were accessed → rotate at both SSM/Secrets Manager and the database level
+- [ ] API keys or tokens stored in accessed objects → revoke and reissue
+
+> ⚠️ **If you discover additional exposed data stores or persistence mechanisms during eradication, return to Part 3 (Contain) and block those access paths before continuing.** Eradication is iterative — it's common to cycle between containment and eradication multiple times.
+
+### 4.3 Eradication Validation
+
+Before moving to recovery, confirm that the threat actor's access has been fully removed:
+
+- [ ] Root cause identified and fixed
+- [ ] All access paths closed (policy, credential, grant, endpoint)
+- [ ] All persistence mechanisms identified in 4.2 have been removed
+- [ ] All accessed secrets/credentials rotated
+- [ ] No additional data stores compromised (verified via CloudTrail)
+- [ ] IAM Access Analyzer shows no unintended external access
+- [ ] Macie scan confirms no remaining public/shared exposure
+- [ ] CloudTrail shows no continued unauthorized activity for at least 30 minutes after eradication actions
+
+> 🤖 **Automation opportunity:** AWS Config auto-remediation for `s3-bucket-public-read-prohibited` can automatically re-enable Block Public Access if it's disabled.
+
+---
+
+## Part 4b — Recover
+
+> **CSF 2.0 Function:** Recover
+> **Goal:** Restore legitimate access, remove containment controls, and harden the environment against recurrence. Recovery should only proceed once eradication is validated — restoring access prematurely can re-expose the environment if persistence mechanisms were missed.
+
+### 4.4 Restore Legitimate Access
+
+> ⚠️ Before restoring access, confirm eradication validation (Section 4.3) is complete.
+
+1. **Restore proper access** — ensure legitimate users/services can still access the data they need. If bucket policies were restricted during containment, carefully re-enable only the required access.
+2. **Verify applications** dependent on the data store are functioning. Check application health metrics and logs for access errors.
+3. **If access was overly restricted during containment**, carefully re-enable legitimate access. Review each permission before re-granting — this is an opportunity to implement least privilege.
+
+### 4.5 Harden Against Recurrence
+
+Based on the root cause identified in Section 4.1, implement targeted hardening:
+
+- [ ] **Enable S3 Block Public Access at the account level** (not just bucket level) — prevents future accidental public exposure
+- [ ] **Implement S3 bucket policies with explicit deny** for cross-account access unless specifically needed
+- [ ] **Enable Macie automated sensitive data discovery** on all buckets — ensures data classification stays current
+- [ ] **Implement VPC endpoint policies** that restrict S3 access to specific buckets
+- [ ] **Enable S3 Object Lock** on buckets containing critical data
+- [ ] **Review and reduce IAM permissions** using Access Analyzer unused access findings
+- [ ] **Implement SCPs** to prevent disabling of S3 Block Public Access
+- [ ] **Consider S3 Access Points** for fine-grained access control
+- [ ] **Enable CloudTrail data events** for all sensitive data stores (not just management events)
+- [ ] **Address the specific root cause:**
+  - If public exposure: implement account-level Block Public Access SCP, enable Config rule with auto-remediation
+  - If permission drift: implement regular access reviews, use Access Analyzer to detect unused permissions
+  - If VPC endpoint: implement restrictive endpoint policies as default, use condition keys in bucket policies
+  - If presigned URL: reduce URL expiry, implement VPC endpoint conditions on bucket policies
+
+### 4.6 Recovery Validation
+
+- [ ] Legitimate access patterns restored and verified
+- [ ] Applications and services that use the data stores are functioning normally
+- [ ] No GuardDuty or Macie findings related to this incident remain active
+- [ ] IAM Access Analyzer shows no unintended external or unused access
+- [ ] Application health metrics normal
+- [ ] Data integrity verified (no unauthorized modifications or deletions)
+- [ ] All containment controls have been removed
+- [ ] Monitoring and alerting confirmed operational for affected data stores
+- [ ] AWS Security Incident Response case updated (if applicable)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Capture what happened, when, and why — then use those findings to improve detection, response, and prevention for next time. Post-incident activity is not a one-time report; it generates action items that feed back into Part 1 (Prepare) for this and other playbooks.
+
+### 5.1 Timeline Reconstruction
+
+Build a complete timeline of the incident from initial unauthorized access through recovery. This should be completed within 24–48 hours while events are fresh and CloudTrail data is readily queryable. A clear timeline supports post-incident review, regulatory inquiries, and future detection tuning.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| | Data first accessed by unauthorized party | CloudTrail data events | Threat actor |
+| | Detection alert fired | Macie / GuardDuty / custom | AWS / tooling |
+| | IR team notified | On-call alert | IR Lead |
+| | Data sensitivity confirmed | Data Owner / Macie | Data Owner |
+| | Access path blocked (containment) | CloudTrail | IR team |
+| | Root cause fixed (eradication) | CloudTrail | IR team |
+| | Recovery validated | IR ticket | IR Lead |
+
+**Key metrics:**
+
+These metrics help you measure response effectiveness over time and identify where investment would reduce future incident duration.
+
+| Metric | Value | Why It Matters |
+|---|---|---|
+| Time to Detect (TTD) | *Time from first unauthorized access to detection alert* | Measures detection coverage — are data events and Macie catching anomalies? |
+| Time to Notify (TTN) | *Time from detection to IR team notified* | Measures alerting pipeline effectiveness |
+| Time to Contain (TTC) | *Time from notification to access path blocked* | Measures response readiness and pre-provisioned access |
+| Time to Recover (TTR) | *Time from containment to recovery validated* | Measures eradication thoroughness |
+| Total Incident Duration | | End-to-end impact window |
+| Data Volume Accessed | *Objects/records count, bytes* | Determines notification scope and business impact |
+| Data Sensitivity | *Classification level* | Drives regulatory notification decisions |
+| Data Exfiltrated? | *Confirmed / Suspected / No* | Determines severity of regulatory response |
+| Regulatory Notification Required? | *Yes / No / Under assessment* | Legal/compliance outcome |
+
+### 5.2 Post-Incident Review
+
+Conduct a blameless post-incident review within **5 business days** for P1/P2, **15 business days** for P3/P4. The goal is to identify systemic improvements, not assign blame. Include all stakeholders who participated in the response.
+
+Discussion questions specific to data access:
+
+1. Why was this data accessible to the unauthorized party? Was least privilege applied?
+2. Was the data classified correctly? Did we know it was sensitive before the incident?
+3. How long was the data exposed before detection? Could Macie or GuardDuty have caught it sooner?
+4. Were CloudTrail data events enabled? If not, would they have provided earlier detection?
+5. Was the data encrypted? Did encryption provide any protection in this scenario?
+6. Should this data be in a more restricted environment (dedicated account, VPC endpoint only)?
+7. Are there other data stores with similar exposure risk? (Conduct a broader audit)
+8. Were our preparation steps (Part 1) adequate? Did we have the access, tools, and documentation we needed?
+
+### 5.3 Detection Gap Analysis
+
+For each gap identified during the incident — whether a detection that didn't fire, an alert that wasn't actioned, or a blind spot in coverage — document the root cause and assign an owner to fix it. Detection gaps are the most actionable output of a post-incident review because they directly reduce future time-to-detect.
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., No alert on bulk S3 reads)* | *(CloudTrail data events not enabled)* | *(Enable data events for sensitive buckets)* | | |
+| *(e.g., Public bucket existed for 6 months)* | *(No Macie policy finding alerting)* | *(Enable Macie policy findings + EventBridge alert)* | | |
+| *(e.g., Cross-account access not detected)* | *(No IAM Access Analyzer external access analyzer)* | *(Enable Access Analyzer in all accounts)* | | |
+
+### 5.4 Playbook Update Checklist
+
+Use this incident to improve this playbook. Do not wait for the next scheduled review — update immediately while the gaps are clear. Each incident is an opportunity to make the next response faster and more effective.
+
+- [ ] Were triage questions (Part 2) sufficient? Add/remove as needed.
+- [ ] Were evidence documentation steps accurate for the data store involved?
+- [ ] Were containment actions effective? Any legitimate access disrupted?
+- [ ] Were any new access patterns observed that aren't covered in the containment table?
+- [ ] Were automation opportunities identified? Add references to relevant sections.
+- [ ] Were severity criteria accurate? Did this incident get classified at the right level?
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+---
+
+## Appendix A — Investigation Resources
+
+For detailed Athena queries, S3 server access log analysis, and CLI commands relevant to data access investigations, see:
+
+📁 [`resources/athena-queries-data-access.sql`](resources/athena-queries-data-access.sql)
+
+These queries cover:
+- All S3 data access events for a specific bucket
+- Top accessors of a bucket (identifying anomalous principals)
+- Bulk data access detection (high-volume reads in short time)
+- DynamoDB data access (Scan operations as exfiltration indicators)
+- Secrets Manager / Parameter Store access
+- Principal-grouped access counts and time windows
+- Data staging detection (copies to other buckets or accounts)
+- Specific objects accessed (for impact assessment)
+- Bucket policy and ACL changes (persistence via policy modification)
+- S3 server access log analysis (presigned URLs and anonymous access)
+- Cross-bucket access by a suspect principal
+- Data copy and snapshot operations (confirming exfiltration)
+
+**Macie CLI commands:**
+
+```bash
+# List Macie findings for a specific bucket
+aws macie2 list-findings \
+  --finding-criteria '{
+    "criterion": {
+      "resourcesAffected.s3Bucket.name": {"eq": ["BUCKET_NAME"]},
+      "severity.description": {"eq": ["High", "Critical"]}
+    }
+  }'
+
+# Get finding details
+aws macie2 get-findings --finding-ids FINDING_ID_1 FINDING_ID_2
+```
+
+**IAM Access Analyzer CLI:**
+
+```bash
+# Check for external access to S3 buckets
+aws accessanalyzer list-findings \
+  --analyzer-arn arn:aws:access-analyzer:REGION:ACCOUNT:analyzer/ANALYZER_NAME \
+  --filter '{
+    "resourceType": {"eq": ["AWS::S3::Bucket"]},
+    "status": {"eq": ["ACTIVE"]}
+  }'
+```
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal / Compliance]` owns this section during an active incident.
+
+See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obligation matrix.
+
+**Quick reference for data access incidents:**
+
+| Regulation | Trigger Condition | Timeframe |
+|---|---|---|
+| GDPR Art. 33 | Personal data of EU residents confirmed accessed | 72 hours to supervisory authority |
+| GDPR Art. 34 | High risk to individuals (bulk PII, financial, health) | Without undue delay to individuals |
+| HIPAA | Protected health information accessed | 60 days to HHS + individuals |
+| PCI-DSS | Cardholder data accessed | Immediately to card brands |
+| CCPA/CPRA | California resident personal information accessed | "Most expedient time possible" |
+| PIPEDA | Personal information accessed, real risk of significant harm | As soon as feasible to OPC + individuals |
+
+> ⚠️ The clock starts at **awareness**. If you know sensitive data was accessed, assume notification is required until Legal confirms otherwise.
+
+---
+
+## Appendix C — Reference Links
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+- [AWS Security Incident Response Service](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Well-Architected Framework — Security Pillar: Incident Response](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/incident-response.html)
+- [Amazon Macie User Guide](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
+- [S3 Block Public Access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html)
+- [S3 Access Grants](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-grants.html)
+- [S3 Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points.html)
+- [IAM Access Analyzer](https://docs.aws.amazon.com/IAM/latest/UserGuide/what-is-access-analyzer.html)
+- [AWS Lake Formation Permissions](https://docs.aws.amazon.com/lake-formation/latest/dg/lake-formation-permissions.html)
+- [CloudTrail Data Events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
+- [VPC Endpoint Policies for S3](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-s3.html)
+- [Amazon GuardDuty S3 Protection](https://docs.aws.amazon.com/guardduty/latest/ug/s3-protection.html)
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/)
+- [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/)
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | 2020-10-01 | AWS | Initial release |
+| 2.0 | 2026-05-28 | AWS CIRT | Full rewrite: NIST r3 alignment, template standardization, added Macie integration, S3 Access Grants, Lake Formation, VPC endpoint policies, IAM Access Analyzer, AWS Security IR service, expanded Athena queries, data classification guidance |
+| 2.1 | 2026-06-18 | AWS CIRT | Structural refresh: separated eradication and recovery phases, moved Athena queries to resources file, added context paragraphs and Well-Architected references, removed inline bash commands in favour of procedural descriptions, added "Why It Matters" to metrics, expanded escalation path, added practice workshop resources |

--- a/playbooks/IRP-DataAccess.md
+++ b/playbooks/IRP-DataAccess.md
@@ -78,7 +78,7 @@ The following services each contribute to your ability to detect, investigate, a
 - [ ] **AWS Security Lake** enabled — centralizes security data across services for cross-service correlation and analysis
 
 > 🤖 **Automation opportunity:** Use Macie automated sensitive data discovery to continuously classify data in S3 buckets. Configure EventBridge rules to alert on Macie HIGH findings.
-
+>
 > 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
 ### 1.2 IAM & Access Prerequisites
@@ -164,7 +164,7 @@ Not every alert is a confirmed incident. The purpose of triage is to quickly det
 Whether the activity is confirmed malicious or still under investigation, document the current state of the affected data stores and access patterns. For data access scenarios, the primary evidence sources are CloudTrail (with S3 data events), S3 server access logs, and Macie findings. The priority here is *documenting what you observe* rather than copying logs to a separate location.
 
 > 📌 **Note on evidence storage:** CloudTrail logs and S3 server access logs persist in their configured destinations — they don't disappear if you don't copy them immediately. If you have a dedicated forensic S3 bucket with Object Lock, export findings there for tamper protection. If you don't, that's fine — the primary logs, findings in the console, and notes in your IR ticket are sufficient for most investigations.
-
+>
 > ⚠️ **Do not modify bucket policies or revoke access before documenting current state.** Capture the current configuration first.
 
 **Document the following:**
@@ -189,6 +189,7 @@ For detailed Athena queries to investigate data access (bulk read detection, pri
 **Quick CloudTrail Console approach (no Athena required):**
 
 If Athena is not configured, you can investigate directly in the CloudTrail console:
+
 1. Navigate to **CloudTrail → Event history**
 2. Filter by **Event source** = `s3.amazonaws.com` and **Event name** = `GetObject`
 3. Review source IPs and principals — compare against known legitimate access patterns
@@ -216,7 +217,7 @@ For P1, P2, or P3 incidents, consider engaging AWS for support. AWS Support and 
 - **AWS Support** (any support plan): Open a support case requesting assistance from the AWS Customer Incident Response Team (CIRT). Include the finding ID(s), the affected data stores, and a summary of the anomalous access you have observed.
 
 > 📌 You do not need the Security Incident Response service to get help from experts. All AWS customers can request CIRT assistance through a support case, regardless of support plan level. For P3 (anomalous access patterns, not yet confirmed), AWS CIRT can help you determine whether the activity is unauthorized or legitimate.
-
+>
 > 🤖 **Automation opportunity:** EventBridge rule on Macie HIGH-severity findings → auto-create Security Incident Response case.
 
 ---
@@ -230,7 +231,7 @@ For P1, P2, or P3 incidents, consider engaging AWS for support. AWS Support and 
 
 The goal of containment is to close the access path so data can no longer be reached by the threat actor, while understanding the impact of that action on legitimate users. Restricting (not deleting) is preferred because it allows you to: (1) observe if legitimate services are impacted, (2) retain the configuration for investigation, and (3) reverse the action if needed.
 
-```
+```text
 Is data actively being exfiltrated RIGHT NOW?
 │
 ├── YES (ongoing bulk reads, active transfer)
@@ -508,6 +509,7 @@ For detailed Athena queries, S3 server access log analysis, and CLI commands rel
 📁 [`resources/athena-queries-data-access.sql`](resources/athena-queries-data-access.sql)
 
 These queries cover:
+
 - All S3 data access events for a specific bucket
 - Top accessors of a bucket (identifying anomalous principals)
 - Bulk data access detection (high-volume reads in short time)

--- a/playbooks/IRP-DoS.md
+++ b/playbooks/IRP-DoS.md
@@ -87,7 +87,7 @@ The following services each contribute to your ability to detect, absorb, and re
 - [ ] **Shield Advanced proactive engagement** configured (requires Route 53 health checks) — SRT contacts you automatically when health checks fail during detected events
 
 > 🤖 **Automation opportunity:** Use AWS Firewall Manager to centrally deploy WAF rules and Shield Advanced protections across all accounts in your organization. EventBridge rules can trigger automatic WAF rule updates when Shield Advanced detects an event.
-
+>
 > 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
 ### 1.2 IAM & Access Prerequisites
@@ -212,6 +212,7 @@ Not every traffic spike is an attack. Legitimate events (product launches, marke
 **Investigation Queries (Athena):**
 
 For detailed log analysis queries (CloudFront, WAF, VPC Flow Logs), see [`resources/athena-queries-dos.sql`](resources/athena-queries-dos.sql). Queries cover:
+
 - Top source IPs by request volume
 - Application-layer attack pattern detection
 - WAF rule effectiveness analysis
@@ -234,6 +235,7 @@ For detailed log analysis queries (CloudFront, WAF, VPC Flow Logs), see [`resour
 **P1 — Service fully unavailable, attack sustained:**
 
 Engage all available AWS resources immediately:
+
 - **Shield Advanced SRT:** Navigate to the [AWS Shield console](https://console.aws.amazon.com/shield/), review the active event, select **Contact the SRT**. SRT can directly modify your WAF rules and create custom mitigations.
 - **AWS Support:** Open a case with Critical severity. Include Shield event ID, affected resources, and current mitigation status.
 - **AWS Security Incident Response service (if subscribed):** Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose **Active Security Incident**.
@@ -250,7 +252,7 @@ Engage all available AWS resources immediately:
 - **Shield Advanced:** Review the Shield console for event classification. Shield Advanced distinguishes between DDoS attacks and legitimate traffic spikes.
 
 > 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
-
+>
 > 🤖 **Automation opportunity:** Configure Shield Advanced proactive engagement so the SRT contacts you automatically when Route 53 health checks fail during a detected DDoS event. This eliminates the need to manually engage during a P1.
 
 ---
@@ -264,7 +266,7 @@ Engage all available AWS resources immediately:
 
 For DoS/DDoS incidents, containment is almost always urgent. Unlike credential compromise where you may observe before acting, availability loss is immediate customer impact. The decision tree focuses on *how aggressively* to contain rather than *whether* to contain.
 
-```
+```text
 Is the service currently unavailable or severely degraded?
 │
 ├── YES (P1/P2 — active impact)
@@ -286,6 +288,7 @@ Is the service currently unavailable or severely degraded?
 
 1. **Verify Shield Advanced auto-mitigation is active**
    Check the Shield console for active mitigations. For resources protected by Shield Advanced, AWS automatically applies network-layer mitigations.
+
    ```bash
    # Check active attacks and mitigations
    aws shield describe-attack --attack-id <attack-id>
@@ -304,7 +307,8 @@ Is the service currently unavailable or severely degraded?
 
 **Application-Layer (Layer 7) Attack Containment:**
 
-4. **Deploy WAF rate-based rule with aggressive threshold**
+1. **Deploy WAF rate-based rule with aggressive threshold**
+
    ```bash
    # Create an emergency rate-based rule (lower threshold than normal)
    aws wafv2 update-web-acl \
@@ -333,16 +337,16 @@ Is the service currently unavailable or severely degraded?
      ]'
    ```
 
-5. **Deploy geographic restriction (if attack is geographically concentrated)**
+2. **Deploy geographic restriction (if attack is geographically concentrated)**
    If traffic analysis shows attack sources concentrated in specific countries that don't serve your legitimate user base, deploy a WAF geographic match rule or CloudFront geographic restriction. Use WAF for granular control (per-endpoint), or CloudFront restrictions for blanket blocking.
 
-6. **Deploy WAF IP blocklist for identified attack sources**
+3. **Deploy WAF IP blocklist for identified attack sources**
    Create or update a WAF IP set with the highest-volume attack source CIDRs identified from log analysis. Reference the IP set in a WAF block rule with high priority.
 
-7. **Adjust Auto Scaling to manage cost exposure**
+4. **Adjust Auto Scaling to manage cost exposure**
    Set a maximum capacity ceiling to prevent runaway scaling costs while maintaining enough capacity for legitimate traffic. For ECS services, adjust the scalable target max-capacity similarly.
 
-8. **Enable CloudFront origin failover (if origin is overwhelmed)**
+5. **Enable CloudFront origin failover (if origin is overwhelmed)**
    If the primary origin is saturated, configure CloudFront to fail over to a static maintenance page or cached content served from S3. This preserves some user experience while protecting the origin.
 
 > 🤖 **Automation opportunity:** EventBridge rule triggered by Shield Advanced `DDoSDetected` metric can automatically invoke a Lambda function that deploys pre-configured WAF rate-based rules and notifies the IR team via SNS.
@@ -428,6 +432,7 @@ Use evidence collected in Part 2 to characterize the attack vector, peak magnitu
 ### 4.3 Recovery Actions
 
 1. **Restore normal Auto Scaling configuration**
+
    ```bash
    # Return Auto Scaling to normal parameters
    aws autoscaling update-auto-scaling-group \
@@ -566,6 +571,7 @@ Athena queries for CloudFront access logs, WAF logs, VPC Flow Logs, and CloudWat
 📄 **[`resources/athena-queries-dos.sql`](resources/athena-queries-dos.sql)**
 
 The file contains queries for:
+
 - **CloudFront:** Top source IPs, application-layer attack pattern detection, User-Agent fingerprinting
 - **WAF:** Blocked/counted request analysis, rate-based rule effectiveness
 - **VPC Flow Logs:** Volumetric attack source identification, protocol/port distribution
@@ -595,7 +601,7 @@ See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obl
 | APRA CPS 234 (Australia) | Material information security incident affecting availability | Notify APRA within 72 hours; notify affected persons as soon as practicable |
 
 > ⚠️ For NIS2 and DORA: The clock starts at **awareness** of the significant impact, not when the attack begins. Availability incidents that breach SLA thresholds are reportable even without data compromise. When in doubt, assume notification is required and consult Legal immediately.
-
+>
 > 📌 **Shield Advanced subscribers:** AWS provides attack forensics reports that can support regulatory notification requirements. Request these from the SRT during or after engagement.
 
 ---
@@ -637,11 +643,13 @@ Target: SNS topic → IR team on-call pager + Slack channel.
 **Rule 3: CloudWatch Composite Alarm → WAF Rule Tightening**
 
 Configure a CloudWatch composite alarm combining:
+
 - ALB 5xx rate > 10% for 2 consecutive periods
 - ALB request count > 5x baseline for 2 consecutive periods
 - Target response time > 5 seconds for 2 consecutive periods
 
 Target: Step Functions workflow that:
+
 1. Lowers WAF rate-based rule threshold
 2. Enables WAF Bot Control (if not already active)
 3. Creates Security Hub custom finding
@@ -650,6 +658,7 @@ Target: Step Functions workflow that:
 ### Shield Advanced Proactive Engagement
 
 When configured, the SRT will automatically contact your designated operations team when:
+
 - A Shield Advanced DDoS event is detected AND
 - Associated Route 53 health checks transition to UNHEALTHY
 

--- a/playbooks/IRP-DoS.md
+++ b/playbooks/IRP-DoS.md
@@ -1,179 +1,732 @@
-# Incident Response Playbook   Template
+# IRP-DoS: Denial of Service / Distributed Denial of Service
 
-### Incident Type
+> **Playbook Version:** 2.1
+> **Last Reviewed:** 2026-06-18
+> **Status:** `Active`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-CredCompromise](IRP-CredCompromise.md) | [IRP-Ransomware](IRP-Ransomware.md) | [IRP-NetworkIntrusion](IRP-NetworkIntrusion.md) (Coming Soon) | [IRP-ResourceHijacking](IRP-ResourceHijacking.md) (Coming Soon)
 
-Web Application Dos/DDoS Attack
-
-### Introduction
-
-This playbook is provided as a template to customers using AWS products and who are building their incident response capability.  You should customize this template playbook to suit your particular needs, risks, available tools and work processes.
-
-Security and Compliance is a shared responsibility between you and AWS. AWS is responsible for “Security of the Cloud”, while you are responsible for “Security in the Cloud”. For more information on the shared responsibility model, [please review our documentation](https://aws.amazon.com/compliance/shared-responsibility-model/).
-
-You are responsible for making your own independent assessment of the information in this document. This document: (a) is for informational purposes only, (b) references current AWS product offerings and practices, which are subject to change without notice, and (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. This document is provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
-
-## Summary
-
-### This Playbook
-This playbook outlines response steps for Web Application Dos/DDoS Attack incidents.  These steps are based on the [NIST Computer Security Incident Handling Guide]   (https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) that can be used to:
-
-* Gather evidence
-* Contain and then eradicate the incident
-* recover from the incident
-* Conduct post-incident activities, including post-mortem and feedback processes
-
-Interested readers may also refer to the [AWS Security Incident Response Guide]( https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) which contains additional resources.
-
-Once you have customized this playbook to meet your needs, it is important that you test the playbook (e.g., Game Days) and any automation (functional tests), update as necessary to achieve the desired results, and then publish to your knowledge management system and train all responders.
-
-Note that some of the incident response steps noted in each scenario may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing these scenarios and testing them will help you to determine if additional costs will be incurred. You can use [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be.
-
-In reviewing this playbook, you will find steps that involve processes that you may not have in place today. Proactively preparing for incidents means you need the right resource configurations, tools and services in place that allow you to respond to an incident.
-
-The next section will provide a summary of this incident type, and then cover the five steps (parts 1 - 5) for handling DoS and DDoS attacks.
-
-### This Incident Type
-DoS and DDoS attacks are “denial of service” attacks, designed to prevent legitimate users from accessing your web applications. They target different layers of the OSI model and often exploit protocol weaknesses. Other attacks may simply use legitimate requests to your web application, but increase the volume of those requests to a point where your web application is overwhelmed and no longer able to service legitimate requests. When you use AWS services, you benefit from protections built in to those services. Additionally, if you follow the [AWS Best Practices for DDoS Resiliency]( https://docs.aws.amazon.com/whitepapers/latest/aws-best-practices-ddos-resiliency/aws-best-practices-ddos-resiliency.pdf), you will increase the availability of your application and its ability to withstand DDoS attacks.
-
-## Incident Response Process
 ---
-### Part 1: Acquire, Preserve, Document Evidence
 
-1.	You become aware that your application is not meeting availability requirements. This may mean that the application is unavailable, is providing a degraded service, or even appears to be functioning, but application performance metrics or logging are suggesting that there may be an issue. This information could come via different means, for example:
-  - Customer contact/feedback/support calls
-  - An internal ticketing system (the sources of the ticket are varied and could include any of the means below)
-  - A message from a contractor or third-party service provider
-  - From an alert in one of your own monitoring systems either internal or external to AWS (for example, in AWS, in this particular situation, it could be via CloudWatch metrics triggering an alarm from Amazon EC2, AWS Application Load Balancer, Amazon CloudFront, AWS WAF or other services that you have configured CloudWatch alarms for)
-  - Via an anonymous tip
-  - Via independent or external security researchers
-2. Confirm an internal ticket/case has been raised for the incident within your organization. If not, manually raise one.
-3. Determine and begin to document end-user impact/experience of the issue. This should be documented in the ticket/case related to the incident
-4. In the case of automatically created tickets/cases, determine what internal alarms/metrics are currently indicating an issue (what caused the ticket to be created?)
-5. Determine the application impacted (this may be done quickly via Resource Tags)
-6. Determine if there are any known events that could be causing disruption to your application (increased traffic due to a sales event, or similar)
-7. Check your Configuration Management Database (CMDB) to determine if there were any deployments to your production environment (code, software or infrastructure updates) that may result in an increase in traffic to the affected URL(s)
-8. Incident Communications:
-    1. Identify stakeholder roles from the application entry in the CMDB entry for that application, or via the application’s risk register
-    2. Open a conference bridge war room for the incident
-    3. Notify identified stakeholders including (if required) legal personnel, public relations, technical teams and developers and add them to the ticket and the war room, so they are updated as the ticket is updated
-9. External Communications:
-    1. Ensure your organizations legal counsel is informed and is included in status updates to internal stakeholders and especially in regards to external communications.
-    2. For colleagues in the organization that are responsible for providing public/external communication statements, ensure these internal stakeholders are added to the ticket so they receive regular status updates regarding the incident and can complete their own requirements for communications within and external to the business.
-    3. If there are regulations in your jurisdiction requiring reporting of such incidents, ensure the people in your organization responsible for notifying local or federal law enforcement agencies are also notified of the event/added to the ticket. Consult your legal advisor and/or law enforcement for guidance on collecting and preserving the evidence and chain of custody.
-    4. There may not be regulations, but either open databases, government agencies or NGOs may track this type of activity. Your reporting may assist others
-10. Determine the resources involved in serving the application (start with front-end resources, including CDNs, load balancers and front-end application servers, then move to supporting services, such as databases, caches, etc.)
-11. Obtain the application’s documented baseline and locate the metrics for standard application performance from the CMDB.
-12. Determine if the application’s resources are currently displaying metrics outside the baseline:
-    1. For Amazon CloudFront, check the following metrics:
-        1. Confirm if there is a significant variation in:
-            1. [Data transferred](https://aws.amazon.com/cloudfront/reporting/) over HTTP and/or HTTPS
-            2. [Total number](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/monitoring-using-cloudwatch.html) of HTTP requests
-        2. If monitoring CloudFront access logs, determine if there has been a spike in 4xx or 5xx HTTP return codes (in Amazon CloudWatch, All >> CloudFront >> Per-Distribution Metrics) with a Metric Name of 5xxErrorRate or 4xxErrorRate
-    2. For Application Load Balancers, [check the following metrics](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-cloudwatch-metrics.html), which may give further information on the type of attack, and how it is impacting your application:
-        1. Confirm if there is a significant variation in:
-            1. HTTPCode_ELB_4xx_Count (indicators of attacks that may involve credential stuffing, malformed or incomplete requests, or overly aggressive website scraping, etc.)
-            2. HTTPCode_ELB_2xx_Count (a dramatic increase may indicate a HTTP flood attack)
-            3. ActiveConnectionCount (indicates total concurrent TCP connections to ALB, when used with SUM)
-            4. ClientTLSNegotiationErrorCount (this may indicate a protocol exploitation attack by abusing the SSL handshake process, such as sending only weak ciphers in a request)
-            5. RequestCount (a significant increase in requests may indicate a HTTP flood attack)
-            6. HTTPCode_Target_5XX_Count (as this is a response dedicated by a host or container behind the load balancer, this may indicate that the server is unable to respond to the number of received requests, this may also be the result of impacted services downstream, such as a supporting database)
-            7. TargetResponseTime (increasing response times may indicate server resources are not available to serve requests from the load balancer)
-            8. ELBAuthFailure (indicates that user authentication could not be completed, as the IdP denied access to the user, or a user attempted to replay an already used auth token)
-        2. Note the metrics of concern
-    3. For Amazon Elastic Compute Cloud (Amazon EC2) instances, check the [following metrics](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring_ec2.html):
-        1. Confirm if there is significant variation in:
-            1. CPU utilization
-            2. Network utilization
-            3. Disk performance
-            4. Memory utilization (if using the [CloudWatch Logs Agent](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.html))
-        2. Note the metrics of concern
-13. Obtain logs relevant to the incident (these will be the logs from the resources identified above, in point 4), these should include the following (note that these logs should be already configured to be sent to CloudWatch Logs):
-    1. Web server access logs
-        1. RHEL-based - /var/log/apache/access.log, or
-        2. Debian-based - /var/log/apache2/access.log
-    2. Load balancer logs:
-        1. Application    Load Balancer Logs will be configured for the ALB and [sent to an Amazon Simple Storage Service (Amazon S3) bucket](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html). If you are not sure which bucket the logs are being sent to, [use this document to help you determine the bucket name](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#enable-access-logging).
-    2. CloudFront Distribution logs. CloudFront will be configured to [send its access logs to an S3 bucket](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html).
-14. Once you have verified you have access to the logs, use your preferred tool (for example, Amazon Athena, internal, or third-party tools   ) to review the logs and determine if there are any identifiable attack signatures. Such signatures may be the following:
-    1. An unusual number of requests within a given time period
-    2. An unusual set of source IPs
-    3. A set of unrecognized URLs in the request section
-    4. POST or Query parameters that are not expected or supported by the application
-    5. Unexpected HTTP verbs (GET, where we expect POST, etc)
-    6. An unusually high number of 2xx, 4xx or 5xx responses
-15. From the log dive outlined in previous steps, determine the likely attack vector (HTTP flood, SYN flood, credential stuffing, UDP reflection attack, etc.)
-16. What resources are being targeted? Note the Amazon resource names (ARN)
-17. Note specific information about the service hosted on the AWS resources For example, what type of application is it? What is the provenance of the application code? Are there other dependencies on this application?
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
 
-### Part 2: Contain the Incident
+---
 
-From the Acquire, Preserve, Document Evidence phase, you should now have a good idea of the attack vector. The following steps describe how to help to mitigate the attack.
+## Overview
 
-1. If it is a single EC2 instance serving the public content:
-    1. determine from the application’s developer whether the application is “cloud native” (can handle things such as Amazon EC2 Auto Scaling   , for example as application instances spin up and down).
-    2. Determine the AMI ID for the EC2 instance(s) identified during the evidence phase and determine if this is an approved image for this application
-    3. If there is no pre-defined image for spinning up additional EC2 instances, consult with the application developer whether an image can be created from the existing instance, and additional instances spun up from that image. If this is possible, proceed with those steps
-    4. From EC2 metrics in CloudWatch outlined in the evidence phase (Part 1), determine if the most suitable[EC2 instance type ](https://aws.amazon.com/ec2/instance-types/) is in use and/or if additional instances should be added behind an [AWS elastic load balancer](https://aws.amazon.com/elasticloadbalancing/) to spread the load
-    5. If so, this will allow you to scale additional EC2 instances using [Amazon EC2 Auto Scaling](https://docs.aws.amazon.com/autoscaling/ec2/userguide/GettingStartedTutorial.html), and put those instances behind an appropriate load balancer
-    6. Update DNS records in your Hosted Zone to point to the load balancer. For security groups on the EC2 instance, allow access only from the load balancer’s security group, and do not allow direct public access from any port or protocol
-2. If it is a group of EC2 instances behind a load balancer:
-    1. Determine if Amazon EC2 Auto Scaling  is in use.
-        1. If not, create an Auto Scaling Group, define a [Launch Configuration](https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-config.html) or [Launch Template](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html) and add the existing instances to the Auto Scaling Group
-        2. If it is in use, move to step (2b).
-    2. Confirm with the relevant stakeholders that CloudFront can be used and;
-    3. [Deploy a CloudFront distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-creating-console.html), using the load balancer as an origin for the distribution
-3. If it is a load balancer (or EC2 instance) behind a CloudFront distribution
-    1. Determine if it is a single EC2 instance serving as an origin:
-        1. If so, go to step 1 and work through those steps
-        2. If it is not, verify the following:
-            1. There is a load balancer
-            2. The target groups are spread across multiple Availability Zones
-            3. The EC2 instances are managed by EC2 Auto Scaling
-        3. If any of the points in (ii) are not true, go back and work through step 2, above
-        4. Finally, ensure that the security groups for the load balancer are appropriately configured. This can be done automatically by using AWS Lambda and the AWS published IP ranges for CloudFront. There is a [Git Repository with code that will set this up for you](https://github.com/aws-samples/aws-cloudfront-samples) and maintain the ranges if there are changes to the public IP ranges published.
+Denial of Service (DoS) and Distributed Denial of Service (DDoS) attacks attempt to make AWS-hosted applications and services unavailable to legitimate users by overwhelming them with traffic or exploiting application-layer vulnerabilities. These attacks range from volumetric floods (Layer 3/4) that saturate network capacity, to protocol attacks that exhaust connection state tables, to sophisticated application-layer (Layer 7) attacks that target specific API endpoints or application logic. In AWS environments, DDoS attacks may target CloudFront distributions, Application Load Balancers, API Gateway endpoints, Route 53 hosted zones, or directly-exposed EC2 instances. The impact ranges from degraded performance to complete service unavailability, with potential cascading effects on dependent systems and significant financial exposure from auto-scaling costs.
 
-### Part 3: Eradicate the Incident
+### Out of Scope
 
-By following steps 1 through to 4 in PART 2, the service is now behind a CloudFront distribution, in addition to the standard protections provided by [AWS Shield](https://docs.aws.amazon.com/whitepapers/latest/aws-best-practices-ddos-resiliency/aws-best-practices-ddos-resiliency.pdf) . Now further refine protections by using AWS WAF.
+This playbook does **not** cover:
 
-1. Determine if the CloudFront distribution or Application Load Balancer are protected by an AWS WAF WebACL.
+- **Resource hijacking for cryptomining or botnet participation** — If compromised resources are generating outbound DoS traffic (your infrastructure as the attack source), see [IRP-ResourceHijacking](IRP-ResourceHijacking.md) (Coming Soon).
+- **Credential compromise leading to service disruption** — If a threat actor uses stolen credentials to delete resources or modify configurations causing an outage, see [IRP-CredCompromise](IRP-CredCompromise.md).
+- **Ransomware with availability impact** — If the availability loss is due to encryption of data or systems, see [IRP-Ransomware](IRP-Ransomware.md).
+- **Network intrusion with lateral movement** — If the DoS is a diversion for active network intrusion, pivot to [IRP-NetworkIntrusion](IRP-NetworkIntrusion.md) (Coming Soon) once the intrusion is confirmed.
 
-    1. For a CloudFront distribution:
-        1. Go to the CloudFront console and click on the name of the relevant distribution
-        2. Under the **General** tab, make note of the value in the AWS WAF Web ACL field
-        3. Go to the AWS WAF and Shield console and select Web ACLs from the navigation pane
-        4. Locate the Web ACL with the same name as noted from step (ii) and click on the name of the Web ACL listed under **AWS WAF**
-    2. For an Application Load Balancer:
-        1. Go to the EC2 console and select “Load Balancers” from the “Load Balancing” menu in the navigation pane
-        2. Select the name of the relevant Application Load Balancer and in the tabs below, select “Integrated services”
-        3. Note the name of the Web ACL listed under **AWS WAF**
-    3. Review the Web ACL and add rules if required;
-        1. The quickest solution is to deploy a set of AWS WAF Managed Rules. These are available in the AWS Marketplace for [third-party providers](https://aws.amazon.com/marketplace/solutions/security/waf-managed-rules). There are also AWS-Managed rules available directly from AWS when you [create a new Web ACL](https://aws.amazon.com/blogs/aws/announcing-aws-managed-rules-for-aws-waf/).
-        2. Alternatively, if the application developers know what type of rules should be deployed to protect the application, work with those developers to [create the rules](https://docs.aws.amazon.com/waf/latest/developerguide/classic-web-acl-rules-creating.html), deploy the Web ACL and then go back to step (a), above.
+### Applicable Finding Types
 
-1. If it is determined that the CloudFront distribution or Application Load Balancer are not protected by a Web ACL, take one of the two following steps:
-    1. If a Web ACL already exists and your CMDB shows that this Web ACL should be associated to either the CloudFront Distribution or the Application Load Balancer, go to the AWS console or AWS Command Line Interface (AWS CLI) tools and associate that resource to the Web ACL.
-    2. If no reference exists to a Web ACL in the CMDB that should be associated to either the CloudFront Distribution or Application Load Balancer, there are now two possible options:
-        1. If the CMDB contains references to known Web ACL rules that should be contained in a Web ACL, go ahead and create those rules and add them to a new Web ACL. Finally, associate that Web ACL to the resources to be protected.
-        2. If the CMDB does not contain references to Web ACL rules that should be deployed, the quickest solution is to deploy a set of AWS WAF Managed Rules. These are available in the AWS Marketplace for [third-party providers](https://aws.amazon.com/marketplace/solutions/security/waf-managed-rules). There are also AWS-Managed rules available directly from AWS when you [create a new Web ACL](https://aws.amazon.com/blogs/aws/announcing-aws-managed-rules-for-aws-waf/).
-        3. Alternatively, if the application developers know what type of rules should be deployed to protect the application, work with those developers to [create the rules](https://docs.aws.amazon.com/waf/latest/developerguide/classic-web-acl-rules-creating.html), deploy the Web ACL and then go back to step (a), above.
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon GuardDuty | `Backdoor:EC2/DenialOfService.Tcp` | HIGH |
+| Amazon GuardDuty | `Backdoor:EC2/DenialOfService.Udp` | HIGH |
+| Amazon GuardDuty | `Backdoor:EC2/DenialOfService.Dns` | HIGH |
+| Amazon GuardDuty | `Backdoor:EC2/DenialOfService.UdpOnTcpPorts` | HIGH |
+| Amazon GuardDuty | `Backdoor:EC2/DenialOfService.UnusualProtocol` | HIGH |
+| Amazon GuardDuty | `Impact:EC2/PortSweep` | MEDIUM |
+| Amazon GuardDuty | `Trojan:EC2/DGADomainRequest.B` | HIGH |
+| Amazon GuardDuty | `Trojan:EC2/DNSDataExfiltration` | HIGH |
+| AWS Shield Advanced | DDoS event detected (Layer 3/4 or Layer 7) | CRITICAL |
+| AWS WAF | Rate-based rule triggered / Bot Control detection | MEDIUM |
+| CloudWatch | ALB 5xx rate > threshold / Target response time spike | — |
+| CloudWatch | CloudFront 5xx error rate > threshold | — |
+| CloudWatch | API Gateway 429/5xx rate spike | — |
+| VPC Flow Logs | Anomalous inbound traffic volume from multiple sources | — |
+| CloudFront Access Logs | Request rate anomaly / geographic concentration | — |
+| Route 53 | Health check failures across multiple endpoints | — |
 
-### Part 4: Recover from the Incident
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list. Shield Advanced events are visible in the AWS Shield console and via CloudWatch metrics in the `AWS/DDoSProtection` namespace.
 
- The next step is to determine if the attack has been mitigated, or if additional tuning is needed to eradicate the attack. This includes reviewing pre- and post-mitigation logs to:
+### Severity Classification
 
-* Determine the impact of the mitigations already performed
-* Identify attack signatures to attempt to eradicate or further mitigate the attack
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | Production service fully unavailable, revenue-impacting, or attack sustained and escalating despite initial mitigations; Shield Advanced SRT engagement required |
+| **P2 — High** | Significant performance degradation to production services, attack confirmed and ongoing, or application-layer attack bypassing existing WAF rules |
+| **P3 — Medium** | Elevated traffic detected triggering rate-based rules, minor latency increase, auto-scaling absorbing load but costs escalating abnormally |
+| **P4 — Low** | Shield Advanced detected and auto-mitigated a volumetric event with no customer-visible impact, or reconnaissance-level probing detected |
 
-From points (9) and (10) in PART 1, review the logs obtained once the incident was detected. Now that mitigations are in place, you need to go back and obtain those metrics and logs again, and compare them to the incident metrics and logs obtained earlier. If request activity has returned to baseline levels, and the service is confirmed to be available, the attack has subsided: Continue to monitor the service post-attack. If the service request rate is still elevated and the service is available, the attack has been mitigated: Continue to monitor the service for potential change in attack method. If the service is unavailable, return to Part 1 and review logs and related data to determine if you have correctly identified the attack vector, or if the attacker has changed the vector in response to the mitigation, or if your mitigations need to be refined.
+---
 
-### Part 5: Post-Incident Activity
+## Part 1 — Prepare
 
-This “sharpen the saw” activity helps teams to assess their response to the actual incident, determine what worked and what didn’t, update the process based on that information and record these findings.
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
 
+### 1.1 Recommended AWS Service Configurations
 
-1. Review the incident handling and the incident handling process with key stakeholders identified in Part 1, Step 6.
-2. Document lessons learned, including attack vector(s) mitigation(s), misconfiguration, etc.
-3. Store the artifacts from this process with the application information in the CMDB entry for the application and also in the CMDB entry for the DDoS Response process.
-4. Update risk documents based on any newly discovered threat/vulnerability combinations that were discovered as a result of lessons learned
-5. If new application or infrastructure configuration is required to mitigate any newly identified risks, conduct these change activities and update application and component configuration in the CMDB
+The following services each contribute to your ability to detect, absorb, and respond to DoS/DDoS attacks. None are strictly required, but DDoS resilience is cumulative — each layer you add reduces the potential impact and shortens time-to-mitigation. The more you have enabled, the more likely attacks are absorbed automatically without requiring human intervention.
+
+- [ ] **AWS Shield Standard** enabled (automatic for all AWS accounts) — provides always-on network-layer protection for resources behind CloudFront, Route 53, and Global Accelerator
+- [ ] **AWS Shield Advanced** enabled on critical resources (CloudFront, ALB, NLB, Elastic IP, Global Accelerator, Route 53 hosted zones) — adds enhanced detection, real-time attack visibility, SRT access, and cost protection
+- [ ] **AWS Shield Advanced automatic application-layer DDoS mitigation** enabled — allows Shield to create WAF rules automatically based on observed attack patterns
+- [ ] **AWS WAF** deployed on CloudFront distributions, ALBs, and API Gateway stages — required for application-layer (Layer 7) protection
+- [ ] **WAF rate-based rules** configured with appropriate thresholds per endpoint — the first line of defense against HTTP floods
+- [ ] **WAF Bot Control** managed rule group enabled (targeted or common level) — detects and blocks automated traffic from known bot frameworks
+- [ ] **WAF managed rule groups** enabled (Amazon IP Reputation List, Anonymous IP List) — blocks traffic from known-bad sources without manual rule management
+- [ ] **CloudFront** configured with origin access control (OAC) to protect origins from direct access — prevents threat actors from bypassing edge protections
+- [ ] **Route 53 health checks** configured for all critical endpoints — enables Shield Advanced proactive engagement and CloudFront failover
+- [ ] **VPC Flow Logs** enabled for all production VPCs (sent to S3 for Athena analysis) — provides network-layer visibility for volumetric attack analysis
+- [ ] **CloudWatch alarms** configured for: ALB 5xx rate, target response time, request count, CloudFront error rate — ensures rapid detection when attacks impact availability
+- [ ] **Auto Scaling groups** configured with appropriate minimum, maximum, and scaling policies — absorbs traffic spikes while capping cost exposure
+- [ ] **Amazon GuardDuty** enabled in all regions with findings exported to Security Hub — detects if your resources are *generating* outbound DoS traffic (indicates compromise)
+- [ ] **AWS Global Accelerator** deployed for critical internet-facing applications — provides DDoS resilience at edge with automatic failover
+- [ ] **CloudFront access logging** enabled and delivered to S3 — required for post-incident analysis of request patterns
+- [ ] **WAF logging** enabled and delivered to S3 or CloudWatch Logs — required to assess rule effectiveness during and after attacks
+- [ ] **Shield Advanced proactive engagement** configured (requires Route 53 health checks) — SRT contacts you automatically when health checks fail during detected events
+
+> 🤖 **Automation opportunity:** Use AWS Firewall Manager to centrally deploy WAF rules and Shield Advanced protections across all accounts in your organization. EventBridge rules can trigger automatic WAF rule updates when Shield Advanced detects an event.
+
+> 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
+
+### 1.2 IAM & Access Prerequisites
+
+Effective incident response depends on having the right access available *before* an incident occurs. For DoS/DDoS specifically, containment actions (WAF rule deployment, NACL changes, scaling adjustments) must happen in minutes — provisioning access during an active attack wastes the time you least have. The following recommendations align with [SEC10-BP05 Pre-provision access](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_provision_access.html) from the AWS Well-Architected Framework.
+
+- [ ] **Break-glass IAM role** exists with permissions to: modify WAF rules, update Network ACLs, modify security groups, adjust Auto Scaling policies, and engage Shield Response Team (SRT) — pre-tested and documented
+- [ ] **IR team members can assume the break-glass role** with MFA from a trusted account — validate this works at least quarterly
+- [ ] **Shield Advanced SRT access is pre-authorized** (IAM role for SRT created and associated with Shield Advanced subscription) — required for SRT to modify your WAF rules during engagement
+- [ ] **Access to AWS Security Incident Response console** confirmed (if subscribed) — verify case creation workflow before you need it
+- [ ] **WAF rule templates** (emergency rate-limit, geographic block, IP blocklist) pre-created and tested — deploy in seconds during an attack rather than authoring JSON under pressure
+- [ ] **Network ACL emergency rules** documented and tested (deny rules for known-bad CIDR ranges) — understand the 20-rule-per-direction limit
+- [ ] **AWS Support Enterprise or Business plan** active (required for SRT engagement) — verify plan level before you need it
+
+### 1.3 Communication & Escalation
+
+Clear communication paths reduce confusion during high-pressure incidents. DoS events are particularly time-sensitive — service is actively degraded while you coordinate. Define who needs to be involved, at what severity threshold, and through which channel *before* you need them.
+
+> 📋 Do not include names in this playbook. Use roles only. Maintain a separate, access-controlled contact list with current names, phone numbers, and escalation preferences.
+
+| Role | Responsibility | When to Engage |
+|---|---|---|
+| IR Lead | Overall incident coordination, status updates, SRT liaison | All severity levels — first notified |
+| Account Owner | Business context, authorization for traffic-blocking actions | P1–P3, or when containment may block legitimate traffic |
+| Application Owner | Impact assessment, identification of legitimate traffic patterns | When distinguishing attack from legitimate traffic spikes |
+| Network Engineer | WAF rule deployment, Network ACL changes, traffic analysis | All severity levels — executes containment |
+| Legal / Compliance | Regulatory notification for availability SLA breaches | P1–P2, or when regulated service SLAs are breached |
+| Communications | Customer-facing status page updates, internal messaging | P1–P2, or when customer-visible impact exceeds 15 minutes |
+| AWS Shield Response Team (SRT) | Custom DDoS mitigation via Shield Advanced console | P1/P2, Shield Advanced subscribers only |
+| AWS CIRT | Technical assistance via AWS Support case or Security Incident Response service | P1/P2, when concurrent compromise suspected or attack characterization needed |
+
+**Escalation path:**
+
+1. **Detection:** Automated alert (Shield Advanced, CloudWatch alarm, WAF rate-based rule, Route 53 health check) or human report triggers initial notification.
+2. **Triage (IR Lead, < 10 min):** IR Lead assesses severity using [Section 2.3](#23-severity-determination). Determines if service is impacted and whether existing mitigations are holding.
+3. **Severity-based escalation:**
+   - **P1/P2:** IR Lead engages Network Engineer immediately for containment. Engages SRT in parallel (Shield Advanced subscribers). Notifies Account Owner and Communications. Opens AWS Support case if CIRT assistance needed.
+   - **P3/P4:** IR Lead monitors with Network Engineer. Prepares containment actions. Escalates to P2 if attack intensifies or auto-mitigation fails.
+4. **Status updates:** IR Lead provides updates to stakeholders every 15 minutes (P1), every 30 minutes (P2), or at key milestones (P3/P4).
+
+> 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — recommends identifying and documenting internal and external resources and contact information ahead of time.
+
+### 1.4 Game Day Guidance
+
+Practicing incident response before a real incident occurs builds muscle memory, identifies gaps in tooling and access, and validates that escalation paths work. DDoS response in particular benefits from practice because containment involves multiple AWS services (WAF, Shield, NACLs, Auto Scaling) and coordination with external teams (SRT). Teams that exercise regularly contain incidents faster and make fewer false-positive blocking decisions.
+
+Recommended testing cadence: **Semi-annually** (this is a P1-capable scenario with high likelihood).
+
+Suggested tabletop scenario:
+> *"Your organization's primary API Gateway endpoint serving a customer-facing mobile application begins returning 429 and 503 errors. CloudWatch shows request rates have increased 50x in the last 10 minutes, originating from thousands of unique IP addresses. The requests are valid HTTP POST calls to your /api/v2/search endpoint with randomized but syntactically correct payloads. Your existing WAF rate-based rule (2,000 requests per 5 minutes per IP) is not triggering because each source IP stays below the threshold. Application Auto Scaling is launching new tasks but the database connection pool is saturating. Customer support tickets are arriving."*
+
+**Practice resources (no paid service or support plan required):**
+
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/) — free, hands-on workshops covering incident response scenarios. Deployable in any AWS account.
+- [Incident Response Playbooks Workshop (GitHub)](https://github.com/aws-samples/aws-incident-response-playbooks-workshop/) — hands-on workshop for building and testing playbooks.
+- [AWS Security Workshops catalog](https://workshops.aws/categories/Security) — broader collection of security-focused hands-on labs.
+- [AWS Best Practices for DDoS Resiliency (Whitepaper)](https://docs.aws.amazon.com/whitepapers/latest/aws-best-practices-ddos-resiliency/aws-best-practices-ddos-resiliency.html) — architecture patterns that reduce DDoS exposure.
+
+> 📖 **Reference:** [SEC10-BP04 Develop and test security incident response playbooks](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_playbooks.html) — recommends creating and regularly testing playbooks to verify response processes.
+
+---
+
+## Part 2 — Detect & Analyze
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyze)
+> **Goal:** Confirm whether an incident has occurred, scope its impact, and gather evidence for containment and investigation.
+
+### 2.1 Initial Triage Questions
+
+Not every traffic spike is an attack. Legitimate events (product launches, marketing campaigns, viral content, partner integrations) can produce traffic patterns that resemble DDoS. These triage questions help distinguish attacks from organic spikes and determine appropriate response urgency.
+
+- [ ] What is the traffic pattern? (Sudden spike from many sources, gradual increase, or single-source saturation)
+- [ ] What is the suspected vector? (Volumetric Layer 3/4, protocol attack, or application-layer Layer 7)
+- [ ] Which resources are targeted? (CloudFront distribution, ALB, API Gateway, Route 53, direct EC2/EIP)
+- [ ] Is the service currently degraded or fully unavailable?
+- [ ] Is Shield Advanced detecting and reporting the event? (Check AWS Shield console)
+- [ ] Are existing WAF rules and rate-based rules triggering? (Check WAF metrics)
+- [ ] Is Auto Scaling responding? Is it helping or creating cost exposure?
+- [ ] Can you distinguish attack traffic from legitimate traffic? (User agents, geographic origin, request patterns, correlation with business events)
+- [ ] Is there a known business reason for elevated traffic? (Marketing campaign, partner launch, media coverage)
+- [ ] Is this a diversion for another attack? (Check GuardDuty for concurrent credential or data access findings)
+- [ ] Are Route 53 health checks failing? Is proactive engagement triggered?
+- [ ] What is the financial exposure? (Auto Scaling costs, data transfer costs)
+
+**If service is fully unavailable AND attack is bypassing existing mitigations → P1 immediately.**
+
+### 2.2 Evidence Documentation
+
+> ⚠️ **Prioritize mitigation over evidence collection for DoS incidents.** Unlike credential compromise, the primary goal is restoring availability. Collect evidence in parallel with containment actions — do not delay mitigation to gather logs.
+
+| Evidence Type | How to Collect | Where to Store |
+|---|---|---|
+| Shield Advanced event details | Shield console → Events tab / `aws shield describe-attack` | IR ticket |
+| WAF sampled requests | WAF console → Web ACL → Sampled requests | Forensic S3 bucket |
+| WAF logs (full) | S3 bucket or CloudWatch Logs (if WAF logging enabled) | Forensic S3 bucket |
+| CloudFront access logs | S3 bucket (standard logging) or real-time logs (Kinesis) | Forensic S3 bucket |
+| VPC Flow Logs | S3 or CloudWatch Logs | Forensic S3 bucket |
+| CloudWatch metrics snapshot | CloudWatch console → relevant dashboards | IR ticket (screenshots + metric export) |
+| ALB access logs | S3 bucket (if ALB access logging enabled) | Forensic S3 bucket |
+| API Gateway execution logs | CloudWatch Logs | Forensic S3 bucket |
+| GuardDuty findings (concurrent) | GuardDuty console → export findings | Forensic S3 bucket |
+| Auto Scaling activity | `aws autoscaling describe-scaling-activities` | IR ticket |
+
+**Key CloudWatch Metrics to Monitor:**
+
+| Metric | Namespace | Indicates |
+|---|---|---|
+| `DDoSDetected` | `AWS/DDoSProtection` | Shield Advanced has detected an attack |
+| `DDoSAttackBitsPerSecond` | `AWS/DDoSProtection` | Volumetric attack magnitude |
+| `DDoSAttackRequestsPerSecond` | `AWS/DDoSProtection` | Application-layer attack rate |
+| `HTTPCode_ELB_5XX_Count` | `AWS/ApplicationELB` | Load balancer overwhelmed |
+| `TargetResponseTime` | `AWS/ApplicationELB` | Backend latency (saturation indicator) |
+| `RequestCount` | `AWS/ApplicationELB` | Total request volume |
+| `5xxErrorRate` | `AWS/CloudFront` | Origin or CloudFront errors |
+| `Requests` | `AWS/CloudFront` | Total CloudFront request volume |
+| `4xxErrorRate` | `AWS/ApiGateway` | Rate limiting / throttling active |
+| `Count` | `AWS/ApiGateway` | API request volume |
+| `BlockedRequests` | `AWS/WAFV2` | WAF rules actively blocking |
+| `CountedRequests` | `AWS/WAFV2` | WAF rules matching (count mode) |
+| `HealthCheckStatus` | `AWS/Route53` | Endpoint availability |
+
+**Investigation Queries (Athena):**
+
+For detailed log analysis queries (CloudFront, WAF, VPC Flow Logs), see [`resources/athena-queries-dos.sql`](resources/athena-queries-dos.sql). Queries cover:
+- Top source IPs by request volume
+- Application-layer attack pattern detection
+- WAF rule effectiveness analysis
+- Volumetric attack source identification
+- Protocol and port distribution analysis
+
+### 2.3 Severity Determination
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Service fully unavailable, attack sustained and escalating, existing mitigations ineffective | P1 |
+| Significant degradation confirmed, attack ongoing, WAF rules partially effective | P2 |
+| Elevated traffic detected, rate-based rules triggering, minor latency increase, auto-scaling absorbing | P3 |
+| Shield Advanced auto-mitigated with no customer impact, or low-level probing detected | P4 |
+
+### 2.4 Getting Help from AWS
+
+> 📌 **If your organization has the AWS Security Incident Response service enabled, or has AWS Support, you can request assistance from the AWS Customer Incident Response Team (CIRT).**
+
+**P1 — Service fully unavailable, attack sustained:**
+
+Engage all available AWS resources immediately:
+- **Shield Advanced SRT:** Navigate to the [AWS Shield console](https://console.aws.amazon.com/shield/), review the active event, select **Contact the SRT**. SRT can directly modify your WAF rules and create custom mitigations.
+- **AWS Support:** Open a case with Critical severity. Include Shield event ID, affected resources, and current mitigation status.
+- **AWS Security Incident Response service (if subscribed):** Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose **Active Security Incident**.
+
+**P2 — Significant degradation, attack confirmed:**
+
+- **Shield Advanced SRT:** Engage if auto-mitigation is insufficient or if you need assistance characterizing application-layer attack patterns.
+- **AWS CIRT:** Engage via support case if you suspect the DoS is covering concurrent credential compromise or data access activity. CIRT can help correlate CloudTrail activity with the DDoS event timeline.
+- **AWS Support:** Open a case with High severity for guidance on WAF rule optimization.
+
+**P3 — Elevated traffic, unclear if attack or organic spike:**
+
+- **AWS CIRT:** Can help determine whether elevated traffic is an attack or legitimate organic spike by analyzing traffic patterns, source reputation, and request characteristics. Open a support case describing the traffic anomaly.
+- **Shield Advanced:** Review the Shield console for event classification. Shield Advanced distinguishes between DDoS attacks and legitimate traffic spikes.
+
+> 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
+
+> 🤖 **Automation opportunity:** Configure Shield Advanced proactive engagement so the SRT contacts you automatically when Route 53 health checks fail during a detected DDoS event. This eliminates the need to manually engage during a P1.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Restore availability by mitigating attack traffic while preserving legitimate user access.
+
+### 3.1 Containment Decision
+
+For DoS/DDoS incidents, containment is almost always urgent. Unlike credential compromise where you may observe before acting, availability loss is immediate customer impact. The decision tree focuses on *how aggressively* to contain rather than *whether* to contain.
+
+```
+Is the service currently unavailable or severely degraded?
+│
+├── YES (P1/P2 — active impact)
+│     └── Proceed immediately to 3.2 — accept risk of blocking some legitimate traffic
+│         └── Engage SRT in parallel if Shield Advanced subscriber
+│
+└── NO (P3/P4 — elevated traffic, no impact yet)
+      └── Monitor closely, prepare containment actions
+            Is the attack escalating?
+            ├── YES → Proceed to 3.2 proactively
+            └── NO  → Continue monitoring, document patterns for future rule creation
+```
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates. `[Network Engineer]` executes. `[Account Owner]` authorizes actions that may block legitimate traffic.
+
+**Layer 3/4 Volumetric Attack Containment:**
+
+1. **Verify Shield Advanced auto-mitigation is active**
+   Check the Shield console for active mitigations. For resources protected by Shield Advanced, AWS automatically applies network-layer mitigations.
+   ```bash
+   # Check active attacks and mitigations
+   aws shield describe-attack --attack-id <attack-id>
+
+   # List all detected events in the last hour
+   aws shield list-attacks \
+     --start-time "$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ)" \
+     --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+   ```
+
+2. **Engage the Shield Response Team (SRT) — P1/P2**
+   If auto-mitigation is insufficient, engage the SRT via the Shield console or AWS Support case with Critical severity. Provide: Shield event ID, affected resources, traffic characteristics observed, and desired mitigation outcome.
+
+3. **Deploy emergency Network ACL rules (direct-to-origin attacks)**
+   If the attack bypasses CloudFront/ALB and targets resources directly, add deny rules for the largest identified source CIDR blocks. NACLs have a 20-rule-per-direction limit — prioritize the highest-volume sources identified from VPC Flow Log analysis.
+
+**Application-Layer (Layer 7) Attack Containment:**
+
+4. **Deploy WAF rate-based rule with aggressive threshold**
+   ```bash
+   # Create an emergency rate-based rule (lower threshold than normal)
+   aws wafv2 update-web-acl \
+     --name "production-web-acl" \
+     --scope REGIONAL \
+     --id <web-acl-id> \
+     --lock-token <lock-token> \
+     --default-action '{"Allow":{}}' \
+     --rules '[
+       {
+         "Name": "EmergencyRateLimit",
+         "Priority": 1,
+         "Statement": {
+           "RateBasedStatement": {
+             "Limit": 300,
+             "AggregateKeyType": "IP"
+           }
+         },
+         "Action": {"Block":{}},
+         "VisibilityConfig": {
+           "SampledRequestsEnabled": true,
+           "CloudWatchMetricsEnabled": true,
+           "MetricName": "EmergencyRateLimit"
+         }
+       }
+     ]'
+   ```
+
+5. **Deploy geographic restriction (if attack is geographically concentrated)**
+   If traffic analysis shows attack sources concentrated in specific countries that don't serve your legitimate user base, deploy a WAF geographic match rule or CloudFront geographic restriction. Use WAF for granular control (per-endpoint), or CloudFront restrictions for blanket blocking.
+
+6. **Deploy WAF IP blocklist for identified attack sources**
+   Create or update a WAF IP set with the highest-volume attack source CIDRs identified from log analysis. Reference the IP set in a WAF block rule with high priority.
+
+7. **Adjust Auto Scaling to manage cost exposure**
+   Set a maximum capacity ceiling to prevent runaway scaling costs while maintaining enough capacity for legitimate traffic. For ECS services, adjust the scalable target max-capacity similarly.
+
+8. **Enable CloudFront origin failover (if origin is overwhelmed)**
+   If the primary origin is saturated, configure CloudFront to fail over to a static maintenance page or cached content served from S3. This preserves some user experience while protecting the origin.
+
+> 🤖 **Automation opportunity:** EventBridge rule triggered by Shield Advanced `DDoSDetected` metric can automatically invoke a Lambda function that deploys pre-configured WAF rate-based rules and notifies the IR team via SNS.
+
+```json
+// EventBridge rule pattern for Shield Advanced DDoS detection
+{
+  "source": ["aws.shield"],
+  "detail-type": ["AWS Shield DDoS Attack"],
+  "detail": {
+    "eventTypeCode": ["AWS_SHIELD_DDOS_ATTACK"]
+  }
+}
+```
+
+### 3.3 Document Containment Actions
+
+Record all containment actions taken for post-incident review and regulatory compliance:
+
+- [ ] WAF logs are being captured for the duration of the attack (verify logging is not throttled)
+- [ ] CloudFront access logs are being delivered (check for delivery delays)
+- [ ] VPC Flow Logs are active and capturing (verify no gaps)
+- [ ] Shield Advanced attack details exported (`aws shield describe-attack`)
+- [ ] CloudWatch metrics exported for the attack window (ALB, CloudFront, WAF, Shield namespaces)
+- [ ] WAF sampled requests captured (console → Web ACL → Sampled requests)
+- [ ] Screenshots of Shield console event timeline preserved
+- [ ] Document: what action was taken, when (UTC timestamp), by whom (role), and authorization received
+
+---
+
+## Part 4 — Eradicate & Recover
+
+> **CSF 2.0 Function:** Respond (Eradicate) · Recover
+> **Goal:** Confirm the attack has subsided, remove emergency mitigations where appropriate, validate service health, and harden against recurrence.
+
+Unlike credential compromise where eradication involves removing threat-actor-created persistence, DoS eradication is about confirming the attack has ended and ensuring your environment is hardened against recurrence. Do not rush to relax emergency mitigations — attacks commonly resume after brief pauses to test whether defenses have been lowered.
+
+### 4.1 Root Cause Identification
+
+> `[IR Lead]` owns this step. Document findings in the IR ticket in real time.
+
+Determine the root cause and attack characteristics before relaxing mitigations. Common root causes for DoS/DDoS in AWS environments:
+
+- **Publicly exposed origin** — Application Load Balancer or EC2 instance directly accessible without CloudFront/WAF protection, allowing threat actors to bypass edge mitigations
+- **Insufficient rate limiting** — No WAF rate-based rules, or thresholds set too high to catch distributed attacks
+- **Application-layer vulnerability** — Expensive API endpoint (complex database query, large response payload) exploitable at low request rates
+- **Missing Shield Advanced protection** — Critical resources not enrolled in Shield Advanced, limiting auto-mitigation capability
+- **DNS amplification exposure** — Open resolvers or misconfigured Route 53 settings enabling reflection attacks
+- **Inadequate scaling configuration** — Auto Scaling maximum too low (causing unavailability) or too high (causing cost explosion)
+- **Lack of geographic or bot controls** — No geographic restrictions or bot detection on endpoints that don't serve global traffic
+
+Use evidence collected in Part 2 to characterize the attack vector, peak magnitude, duration, and source distribution.
+
+### 4.2 Eradication Actions
+
+> `[IR Lead]` coordinates. `[Network Engineer]` executes. `[Account Owner]` approves changes to production resources.
+
+1. **Confirm attack has subsided**
+   Monitor Shield Advanced metrics and WAF block rates for at least 30 minutes of sustained normal levels before declaring the attack over. Verify in the Shield console that no active events are reported, and confirm CloudWatch metrics (request count, 5xx rate, target response time) have returned to baseline.
+
+2. **Gradually relax emergency mitigations**
+   Do not remove all emergency rules simultaneously. Relax in stages and monitor for attack resumption:
+   - Stage 1: Increase emergency rate-limit threshold (e.g., 300 → 1,000 per 5 min) — monitor for 30 minutes
+   - Stage 2: Remove geographic blocks (if legitimate traffic from those regions is expected) — monitor for 1 hour
+   - Stage 3: Remove emergency IP blocklist entries (after 24–48 hours of no activity from those sources)
+   - Stage 4: Remove emergency Network ACL deny rules
+
+3. **Convert effective emergency rules to permanent protections**
+   If emergency WAF rules proved effective, create production-grade versions:
+   - [ ] Rate-based rules with appropriate long-term thresholds
+   - [ ] Bot Control rules for endpoints that were targeted
+   - [ ] Custom rules matching the specific attack signature (user agent, URI pattern, header anomalies)
+
+4. **Verify no secondary compromise occurred**
+   DDoS attacks are sometimes used as a diversion. Check for:
+   - [ ] Unusual IAM activity during the attack window (credential compromise under cover of DoS)
+   - [ ] Unauthorized resource creation or configuration changes
+   - [ ] Data access events that occurred while the team was focused on availability
+   - [ ] New GuardDuty findings unrelated to the DoS event
+
+> 🤖 **Automation opportunity:** Create an EventBridge rule that triggers when Shield Advanced reports attack mitigation complete, automatically adjusting WAF rate-based rule thresholds back to normal levels after a configurable cool-down period.
+
+### 4.3 Recovery Actions
+
+1. **Restore normal Auto Scaling configuration**
+   ```bash
+   # Return Auto Scaling to normal parameters
+   aws autoscaling update-auto-scaling-group \
+     --auto-scaling-group-name "production-asg" \
+     --max-size <normal-max> \
+     --desired-capacity <normal-desired>
+   ```
+
+2. **Validate service health**
+   - [ ] All Route 53 health checks passing
+   - [ ] ALB target group healthy host count at expected level
+   - [ ] Application response times within normal range
+   - [ ] Error rates (4xx, 5xx) returned to baseline
+   - [ ] Customer-facing functionality confirmed operational (synthetic monitoring)
+
+3. **Harden against recurrence**
+   - [ ] Enroll all internet-facing resources in Shield Advanced (if not already)
+   - [ ] Enable Shield Advanced automatic application-layer DDoS mitigation
+   - [ ] Configure proactive engagement (requires Route 53 health checks)
+   - [ ] Deploy WAF Bot Control on targeted endpoints
+   - [ ] Implement CloudFront origin access control to prevent direct origin access
+   - [ ] Review and lower rate-based rule thresholds based on attack analysis
+   - [ ] Deploy AWS Global Accelerator for critical endpoints (provides additional DDoS resilience)
+   - [ ] Implement request validation (API schema validation, payload size limits) to reduce application-layer attack surface
+   - [ ] Configure CloudFront origin shield to reduce origin load
+
+### 4.4 Resolution Confirmation
+
+Confirm the environment is stable before declaring the incident resolved.
+
+- [ ] Attack traffic has ceased for at least 2 hours (monitor Shield Advanced metrics)
+- [ ] All emergency mitigations either removed or converted to permanent rules
+- [ ] Application performance metrics within normal range for at least 1 hour
+- [ ] Route 53 health checks all passing
+- [ ] Auto Scaling configuration returned to normal parameters
+- [ ] No secondary compromise indicators detected (GuardDuty, CloudTrail review)
+- [ ] Customer-facing status page updated (if previously communicated)
+- [ ] Shield Advanced SRT case closed (if engaged)
+- [ ] AWS Security Incident Response case updated / closed (if applicable)
+- [ ] Cost impact assessed (data transfer, Auto Scaling, WAF request charges)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Learn from this incident to reduce the likelihood and impact of future occurrences.
+
+Post-incident activity for DoS events is particularly valuable because DDoS attacks tend to recur. Threat actors who successfully disrupt a target often return — and application-layer attacks in particular evolve to bypass the mitigations you deployed. Investing in post-incident hardening directly reduces future impact.
+
+### 5.1 Timeline Reconstruction
+
+Document the full incident timeline. Complete this within 24–48 hours while memory is fresh.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| YYYY-MM-DD HH:MM | Attack traffic begins | CloudWatch metrics / VPC Flow Logs | Threat actor |
+| YYYY-MM-DD HH:MM | Shield Advanced detects event | Shield console | AWS |
+| YYYY-MM-DD HH:MM | CloudWatch alarm fires / health check fails | CloudWatch / Route 53 | AWS |
+| YYYY-MM-DD HH:MM | IR team notified | On-call alert | Automated |
+| YYYY-MM-DD HH:MM | SRT engaged (if applicable) | Shield console | IR Lead |
+| YYYY-MM-DD HH:MM | Emergency WAF rules deployed | WAF console / CLI | Network Engineer |
+| YYYY-MM-DD HH:MM | Service availability restored | CloudWatch metrics | — |
+| YYYY-MM-DD HH:MM | Attack traffic subsides | Shield Advanced | — |
+| YYYY-MM-DD HH:MM | Emergency mitigations relaxed | WAF / NACL changes | Network Engineer |
+| YYYY-MM-DD HH:MM | Incident declared resolved | IR ticket | IR Lead |
+
+**Key metrics to capture:**
+
+| Metric | Value | Why It Matters |
+|---|---|---|
+| Time to Detect (TTD) | *HH:MM from attack start to first alert* | Measures alarm and monitoring effectiveness |
+| Time to Notify (TTN) | *HH:MM from alert to IR team notified* | Measures alerting pipeline reliability |
+| Time to Mitigate (TTM) | *HH:MM from notification to service restored* | Measures containment speed — primary DoS KPI |
+| Time to Resolve (TTR) | *HH:MM from mitigation to incident closed* | Measures full lifecycle including hardening |
+| Total Incident Duration | *HH:MM* | Overall impact window for SLA calculations |
+| Peak Attack Magnitude | *Gbps (volumetric) or requests/sec (Layer 7)* | Informs capacity planning and Shield engagement thresholds |
+| Service Unavailability Duration | *HH:MM of customer-visible impact* | Direct input to SLA breach assessment |
+| Financial Impact | *Estimated cost (data transfer, scaling, WAF charges)* | Justifies Shield Advanced cost protection claims |
+| Affected Resources | *Count and type* | Informs Shield Advanced enrollment decisions |
+| Legitimate Traffic Blocked | *Estimated false positive rate during mitigation* | Measures containment precision — informs rule tuning |
+
+### 5.2 Post-Incident Review
+
+Conduct a blameless post-incident review within **5 business days** for P1/P2, **15 business days** for P3/P4.
+
+Discussion questions:
+
+1. What type of attack was this? (Volumetric, protocol, application-layer, or combination)
+2. Were the targeted resources protected by Shield Advanced? If not, why not?
+3. How quickly was the attack detected? Could detection have been faster with better alarming?
+4. Did Shield Advanced auto-mitigation work effectively? If not, what was the gap?
+5. Were WAF rules effective? What rules would have caught this attack earlier?
+6. Did the SRT engagement process work smoothly? Were pre-authorizations in place?
+7. Was legitimate traffic blocked during mitigation? How can we reduce false positives?
+8. Did Auto Scaling help or hurt? (Absorbed load vs. created cost exposure)
+9. Was this attack a diversion? Did we check for concurrent security events?
+10. What is the total financial impact (direct costs + revenue loss + remediation effort)?
+11. What single architectural change would most reduce our exposure to this attack type?
+12. Was our preparation adequate? Did we have the right tools, access, and runbooks ready, or did we waste time provisioning during the incident?
+
+### 5.3 Detection Gap Analysis
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., No alarm on API Gateway 5xx rate)* | *(CloudWatch alarm not configured)* | *(Create alarm at 5% 5xx threshold)* | | |
+| *(e.g., Shield Advanced not on ALB)* | *(Resource not enrolled)* | *(Enroll all internet-facing ALBs)* | | |
+| *(e.g., WAF rate-based rule too permissive)* | *(Threshold set at 10,000/5min)* | *(Lower to 2,000/5min per IP)* | | |
+| *(e.g., No bot detection on API endpoint)* | *(Bot Control not enabled)* | *(Enable targeted Bot Control)* | | |
+| *(e.g., Origin directly accessible)* | *(No origin access control)* | *(Deploy CloudFront OAC, restrict origin SG)* | | |
+
+### 5.4 Playbook Update Checklist
+
+- [ ] Were triage questions sufficient for this attack type? Add/remove as needed.
+- [ ] Were the containment actions effective? Update CLI commands and thresholds.
+- [ ] Were any new attack patterns observed? Document for future detection rules.
+- [ ] Were automation opportunities identified? Add EventBridge/Lambda stubs.
+- [ ] Were severity criteria accurate? Adjust if incidents were under- or over-classified.
+- [ ] Were SRT engagement procedures smooth? Update if process gaps found.
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+### 5.5 Shield Advanced Cost Protection
+
+> 📌 For Shield Advanced subscribers: If the attack caused scaling charges, you may be eligible for cost protection credits.
+
+- [ ] Review the [Shield Advanced cost protection eligibility](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-cost-protection.html)
+- [ ] Document scaling charges attributable to the DDoS event
+- [ ] Submit cost protection request via AWS Support within 15 days of the billing cycle
+
+---
+
+## Appendix A — Investigation Resources
+
+Athena queries for CloudFront access logs, WAF logs, VPC Flow Logs, and CloudWatch Logs Insights are maintained in a companion file for easier reuse and version control:
+
+📄 **[`resources/athena-queries-dos.sql`](resources/athena-queries-dos.sql)**
+
+The file contains queries for:
+- **CloudFront:** Top source IPs, application-layer attack pattern detection, User-Agent fingerprinting
+- **WAF:** Blocked/counted request analysis, rate-based rule effectiveness
+- **VPC Flow Logs:** Volumetric attack source identification, protocol/port distribution
+- **CloudWatch Logs Insights:** ALB request patterns causing backend saturation
+- **GuardDuty:** CLI reference for listing DoS-related findings
+
+> 📌 Replace placeholder values (dates, timestamps, target IPs, table names) before running queries. See the file header for prerequisites.
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal / Compliance]` owns this section during an active incident.
+
+See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obligation matrix by regulation and incident type.
+
+**Quick reference for DoS/DDoS scenarios:**
+
+| Regulation | Trigger Condition | Timeframe |
+|---|---|---|
+| NIS2 Directive (EU) | Significant incident affecting availability of essential/important services; service disruption exceeding defined thresholds | 24-hour early warning to CSIRT, 72-hour incident notification, 1-month final report |
+| DORA (EU Financial Sector) | Major ICT-related incident affecting availability of critical financial services | Initial notification without undue delay, intermediate report within 1 week, final report within 1 month |
+| GDPR Art. 33/34 | Personal data unavailability constituting a breach (if availability loss affects data subject rights) | 72 hours to supervisory authority (if risk to data subjects) |
+| SOC 2 (Trust Services Criteria) | Availability commitment breach affecting customer SLAs | Per contractual obligations; document in SOC 2 reporting |
+| PCI DSS v4.0 (Req. 12.10) | Service disruption affecting cardholder data environment availability | Per incident response plan; document and report per acquiring bank requirements |
+| FedRAMP (US Federal) | Significant availability incident affecting federal information systems | US-CERT notification within 1 hour for significant incidents |
+| APRA CPS 234 (Australia) | Material information security incident affecting availability | Notify APRA within 72 hours; notify affected persons as soon as practicable |
+
+> ⚠️ For NIS2 and DORA: The clock starts at **awareness** of the significant impact, not when the attack begins. Availability incidents that breach SLA thresholds are reportable even without data compromise. When in doubt, assume notification is required and consult Legal immediately.
+
+> 📌 **Shield Advanced subscribers:** AWS provides attack forensics reports that can support regulatory notification requirements. Request these from the SRT during or after engagement.
+
+---
+
+## Appendix C — Automation Hooks
+
+### EventBridge Rules for Automated Response
+
+**Rule 1: Shield Advanced DDoS Detection → WAF Emergency Rate Limit**
+
+```json
+{
+  "Source": ["aws.shield"],
+  "DetailType": ["AWS Health Event"],
+  "Detail": {
+    "eventTypeCode": ["AWS_SHIELD_DDOS_ATTACK_DETECTED"],
+    "service": ["SHIELD"]
+  }
+}
+```
+
+Target: Lambda function that deploys pre-configured emergency WAF rate-based rule and sends SNS notification to IR team.
+
+**Rule 2: Route 53 Health Check Failure → IR Team Notification**
+
+```json
+{
+  "Source": ["aws.route53"],
+  "DetailType": ["Route 53 Health Check Status Changed"],
+  "Detail": {
+    "CurrentStatus": ["UNHEALTHY"],
+    "PreviousStatus": ["HEALTHY"]
+  }
+}
+```
+
+Target: SNS topic → IR team on-call pager + Slack channel.
+
+**Rule 3: CloudWatch Composite Alarm → WAF Rule Tightening**
+
+Configure a CloudWatch composite alarm combining:
+- ALB 5xx rate > 10% for 2 consecutive periods
+- ALB request count > 5x baseline for 2 consecutive periods
+- Target response time > 5 seconds for 2 consecutive periods
+
+Target: Step Functions workflow that:
+1. Lowers WAF rate-based rule threshold
+2. Enables WAF Bot Control (if not already active)
+3. Creates Security Hub custom finding
+4. Notifies IR team
+
+### Shield Advanced Proactive Engagement
+
+When configured, the SRT will automatically contact your designated operations team when:
+- A Shield Advanced DDoS event is detected AND
+- Associated Route 53 health checks transition to UNHEALTHY
+
+**Setup requirements:**
+
+1. Route 53 health checks associated with Shield Advanced protected resources
+2. Emergency contact list configured in Shield Advanced settings
+3. Proactive engagement feature enabled in Shield Advanced console
+
+Configure these settings via the [Shield Advanced console](https://console.aws.amazon.com/shield/) under **Proactive engagement** and **Contacts**. Ensure health checks are associated with each protected resource under **Protected resources → Health check association**.
+
+---
+
+## Appendix D — Attack Type Reference
+
+### Layer 3/4 (Volumetric & Protocol Attacks)
+
+| Attack Type | Description | Primary AWS Mitigation |
+|---|---|---|
+| UDP Flood | High-volume UDP packets to saturate bandwidth | Shield Standard/Advanced (automatic) |
+| SYN Flood | TCP SYN packets exhausting connection state | Shield Standard/Advanced (automatic) |
+| DNS Amplification | Spoofed DNS queries generating large responses | Shield Advanced + Route 53 resilience |
+| NTP Amplification | Spoofed NTP monlist requests | Shield Standard/Advanced (automatic) |
+| SSDP Reflection | Spoofed SSDP requests to IoT devices | Shield Standard/Advanced (automatic) |
+| ICMP Flood | High-volume ICMP echo requests | Security Groups (block ICMP) + Shield |
+| IP Fragmentation | Fragmented packets exhausting reassembly buffers | Shield Advanced (automatic) |
+
+**AWS defense posture:** Shield Standard automatically mitigates most Layer 3/4 attacks for resources behind CloudFront, Route 53, and Global Accelerator. Shield Advanced provides enhanced detection, real-time metrics, and SRT access.
+
+### Layer 7 (Application-Layer Attacks)
+
+| Attack Type | Description | Primary AWS Mitigation |
+|---|---|---|
+| HTTP Flood | High-volume legitimate-looking HTTP requests | WAF rate-based rules + Bot Control |
+| Slowloris | Slow, incomplete HTTP connections exhausting server threads | ALB connection timeouts + WAF |
+| RUDY (R-U-Dead-Yet) | Slow POST requests with large Content-Length | ALB request timeout + WAF |
+| Cache-Busting | Requests with unique query strings bypassing CDN cache | CloudFront + WAF custom rules |
+| API Abuse | Targeting expensive API endpoints (search, reports) | WAF rate-based rules + API Gateway throttling |
+| WordPress XML-RPC | Amplification via WordPress pingback | WAF managed rules (WordPress protection) |
+| Login Brute Force | High-volume authentication attempts | WAF rate-based rules + CAPTCHA |
+
+**AWS defense posture:** Layer 7 attacks require WAF rules (rate-based, Bot Control, custom rules) and application-level controls (API Gateway throttling, caching strategies). Shield Advanced automatic application-layer mitigation can create WAF rules based on observed attack patterns.
+
+---
+
+## Appendix E — Reference Links
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+- [AWS Security Incident Response Service Documentation](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Well-Architected Framework — Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [AWS Best Practices for DDoS Resiliency (Whitepaper)](https://docs.aws.amazon.com/whitepapers/latest/aws-best-practices-ddos-resiliency/aws-best-practices-ddos-resiliency.html)
+- [AWS Shield Documentation](https://docs.aws.amazon.com/waf/latest/developerguide/shield-chapter.html)
+- [AWS Shield Advanced — Responding to DDoS Events](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-responding.html)
+- [AWS Shield Response Team (SRT) Engagement](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-srt.html)
+- [AWS WAF Documentation](https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html)
+- [AWS WAF Rate-Based Rules](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based.html)
+- [AWS WAF Bot Control](https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control.html)
+- [Shield Advanced Cost Protection](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-cost-protection.html)
+- [Shield Advanced Proactive Engagement](https://docs.aws.amazon.com/waf/latest/developerguide/ddos-srt-proactive-engagement.html)
+- [CloudFront Security Best Practices](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/security-best-practices.html)
+- [Route 53 DDoS Resilience](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/disaster-recovery-resiliency.html)
+- [AWS Global Accelerator DDoS Protection](https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html)
+- [Amazon GuardDuty Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
+- [VPC Flow Logs Querying with Athena](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-athena.html)
+- [AWS Well-Architected Framework — Reliability Pillar: DDoS Mitigation](https://docs.aws.amazon.com/wellarchitected/latest/reliability-pillar/plan-for-disaster-recovery-dr.html)
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/)
+- [NIS2 Directive — Incident Reporting Requirements](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive)
+- [DORA — Digital Operational Resilience Act](https://www.digital-operational-resilience-act.com/)
+- [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/)
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | 2024-03-15 | IR Team | Initial draft |
+| 2.0 | 2026-05-28 | IR Team | Major refresh: Added Shield Advanced automatic app-layer mitigation, WAF Bot Control, Global Accelerator, EventBridge automation hooks, NIS2/DORA regulatory guidance, expanded Layer 7 containment procedures, updated Athena queries for WAF v2 log format |
+| 2.1 | 2026-06-18 | IR Team | Aligned to playbook template v2: Added context paragraphs, Well-Architected references (SEC10-BP01/04/05/06), moved Athena queries to companion SQL file, trimmed CLI bulk in containment/eradication (kept key examples), added "When to Engage" column, expanded severity to P1–P3 AWS engagement guidance, fixed spelling (characterize/randomized/prioritize), updated terminology (threat actor), added forward references for upcoming playbooks |

--- a/playbooks/IRP-PersonalDataBreach.md
+++ b/playbooks/IRP-PersonalDataBreach.md
@@ -45,7 +45,7 @@ This playbook does **not** cover:
 | External Report | Customer/individual report of data misuse or exposure | — |
 
 > 📌 Amazon Macie sensitive data discovery jobs and automated discovery provide the primary signal for personal data classification. See the [Macie finding types reference](https://docs.aws.amazon.com/macie/latest/user/findings-types.html) for the current list.
-
+>
 > 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
 
 ### Severity Classification
@@ -82,9 +82,9 @@ The following services each contribute to your ability to detect, scope, and doc
 - [ ] **Data classification tags** applied to all data stores (e.g., `DataClassification: PII`, `DataClassification: PHI`, `DataClassification: PCI`) — enables rapid identification of affected data categories during an incident
 
 > 🤖 **Automation opportunity:** Use Macie automated sensitive data discovery with classification jobs to maintain a continuously updated inventory of where personal data resides. Combine with AWS Config rules to alert when untagged buckets contain Macie-identified PII.
-
+>
 > 📌 **Don't have Macie enabled?** Macie can be enabled *during* an incident — it doesn't require historical data to be useful. Enable it on the affected bucket(s) and run an on-demand classification job. Initial results are typically available within 1–4 hours, well within the 72-hour GDPR notification window. If Macie is not available, see [Section 2.2 — Alternative classification approaches](#without-macie-alternative-classification-approaches) for manual methods.
-
+>
 > 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
 ### 1.2 IAM & Access Prerequisites
@@ -125,7 +125,7 @@ Personal data breach escalation is time-critical due to hard regulatory deadline
 6. **Within 24 hours:** Notification decision made and documented (notify or documented justification for non-notification)
 
 > ⚠️ **Critical:** The Privacy Officer / DPO must be notified within **1 hour** of personal data involvement being confirmed. The 72-hour GDPR notification clock starts at awareness — delays in internal escalation directly consume the notification window.
-
+>
 > 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — pre-identify all stakeholders (including legal, privacy, and communications) and establish clear escalation paths before an incident occurs.
 
 ### 1.4 Game Day Guidance
@@ -298,6 +298,7 @@ Run the following queries from [`resources/athena-queries-personal-data-breach.s
 This is the critical question for notification obligations. Data accessed within AWS (e.g., by another AWS service or account) may have different risk implications than data confirmed exfiltrated to an external location.
 
 Indicators of exfiltration:
+
 - GuardDuty `Exfiltration:S3/MaliciousIPCaller` or `Exfiltration:S3/AnomalousBehavior` findings
 - CloudTrail `GetObject` calls from IP addresses outside known AWS ranges
 - VPC Flow Logs showing large outbound data transfers to unknown IPs
@@ -357,7 +358,7 @@ For each jurisdiction where affected individuals reside, assess notification obl
 - Even for lower-severity incidents, AWS CIRT can assist with CloudTrail analysis, Macie interpretation, and evidence documentation that supports regulatory submissions. Consider engaging if your team lacks experience with Athena queries against CloudTrail data events.
 
 > 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
-
+>
 > The AWS Security Incident Response service can assist with evidence gathering and documentation that supports regulatory notification requirements. They do not provide legal advice on notification obligations.
 
 ---
@@ -366,12 +367,12 @@ For each jurisdiction where affected individuals reside, assess notification obl
 
 > **CSF 2.0 Function:** Respond (Contain)
 > **Goal:** Stop further data access, preserve evidence for regulatory investigation, initiate legal hold, and document the notification clock.
-
+>
 > 📌 **Note:** Technical containment of the underlying incident (credential revocation, network isolation, etc.) may already be handled by the parallel technical playbook (IRP-CredCompromise, IRP-DataAccess, IRP-InsiderThreat). This section focuses on containment actions specific to the personal data breach workstream.
 
 ### 3.1 Containment Decision
 
-```
+```text
 Is personal data still actively being accessed or exfiltrated?
 │
 ├── YES (active access ongoing)
@@ -470,6 +471,7 @@ This record establishes the start of the notification clock for GDPR (72 hours),
 Legal hold prevents the routine deletion or modification of evidence that may be required by regulators months or years after the incident. Implement legal hold across all systems that may contain evidence of the breach scope, timeline, or response actions.
 
 Place legal hold on:
+
 - [ ] All S3 access logs for affected buckets (full retention period)
 - [ ] CloudTrail logs for affected accounts (full retention period)
 - [ ] VPC Flow Logs for affected VPCs
@@ -511,7 +513,7 @@ After containment, document and confirm the following before any data modificati
 
 > **CSF 2.0 Function:** Respond (Eradicate) · Recover
 > **Goal:** Confirm the full scope of personal data affected, determine notification content, prepare regulatory submissions, and implement individual protections.
-
+>
 > 📌 **Note:** Technical eradication (removing threat actor access, closing vulnerabilities) is handled by the parallel technical playbook. This section focuses on the regulatory, notification, and individual protection workstream.
 
 ### 4.1 Full Scope Determination
@@ -521,6 +523,7 @@ After containment, document and confirm the following before any data modificati
 Before preparing notifications, confirm the following with as much precision as possible:
 
 **Data scope:**
+
 - [ ] Exact data categories involved (names, emails, government IDs, health data, financial data, etc.)
 - [ ] Number of unique individuals affected (or best estimate with confidence range)
 - [ ] Jurisdictions of affected individuals (determines which regulations apply)
@@ -529,6 +532,7 @@ Before preparing notifications, confirm the following with as much precision as 
 - [ ] Whether data has been confirmed exfiltrated or only accessed
 
 **Individual impact assessment:**
+
 - [ ] What is the likely harm to individuals? (Identity theft, financial fraud, discrimination, reputational damage)
 - [ ] Are vulnerable populations affected? (Children, patients, employees)
 - [ ] Can affected individuals be individually identified for notification?
@@ -578,6 +582,7 @@ Each regulatory notification should include (adapt per jurisdiction requirements
 **AWS Artifact for compliance documentation:**
 
 Use [AWS Artifact](https://console.aws.amazon.com/artifact/) to retrieve:
+
 - AWS SOC 2 Type II report (demonstrates AWS infrastructure security controls)
 - AWS PCI-DSS Attestation of Compliance (if PCI data involved)
 - AWS ISO 27001 certificate
@@ -590,6 +595,7 @@ These documents may be requested by regulators to demonstrate the security postu
 > `[Communications Lead]` manages notification delivery. `[Customer Support Lead]` manages incoming inquiries.
 
 **Notification delivery:**
+
 - [ ] Individual notification content finalized and approved by Legal
 - [ ] Notification delivery method determined (email, postal mail, public notice)
 - [ ] Dedicated support channel established (phone line, email address, FAQ page)
@@ -598,6 +604,7 @@ These documents may be requested by regulators to demonstrate the security postu
 - [ ] Delivery confirmation tracked (email delivery receipts, postal tracking)
 
 **Individual protection measures (if applicable):**
+
 - [ ] Credit monitoring service enrolled for affected individuals (if government IDs or financial data exposed)
 - [ ] Identity protection service offered (if Tier 1 or Tier 2 data exposed)
 - [ ] Password reset forced for affected accounts (if credentials exposed)
@@ -805,7 +812,7 @@ See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obl
 
 ### C.1 Regulator Notification Template (GDPR Art. 33)
 
-```
+```text
 PERSONAL DATA BREACH NOTIFICATION
 Submitted pursuant to Article 33 of the General Data Protection Regulation
 
@@ -847,7 +854,7 @@ Submitted pursuant to Article 33 of the General Data Protection Regulation
 
 ### C.2 Individual Notification Template
 
-```
+```text
 Subject: Important Notice About Your Personal Data
 
 Dear [Name / "Valued Customer"],
@@ -895,7 +902,7 @@ Sincerely,
 
 ### C.3 Internal Stakeholder Briefing Template
 
-```
+```text
 PERSONAL DATA BREACH — INTERNAL BRIEFING
 Classification: CONFIDENTIAL — DO NOT DISTRIBUTE EXTERNALLY
 

--- a/playbooks/IRP-PersonalDataBreach.md
+++ b/playbooks/IRP-PersonalDataBreach.md
@@ -568,7 +568,7 @@ Each regulatory notification should include (adapt per jurisdiction requirements
 | Jurisdiction | Submission Method | Key Deadlines | Status |
 |---|---|---|---|
 | EU/EEA (GDPR) | DPA online portal (varies by member state) | 72 hours initial; follow-up as needed | ☐ Submitted ☐ Pending |
-| UK (ICO) | [ICO breach reporting tool](https://ico.org.uk/for-organizations/report-a-breach/) | 72 hours | ☐ Submitted ☐ Pending |
+| UK (ICO) | [ICO breach reporting tool](https://ico.org.uk/for-organisations/report-a-breach/) | 72 hours | ☐ Submitted ☐ Pending |
 | Canada (PIPEDA) | [OPC breach report form](https://www.priv.gc.ca/en/report-a-concern/report-a-privacy-breach-at-your-organization/) | As soon as feasible | ☐ Submitted ☐ Pending |
 | California (CCPA) | [California AG breach reporting](https://oag.ca.gov/privacy/databreach/reporting) | Most expedient time possible | ☐ Submitted ☐ Pending |
 | Australia (NDB) | [OAIC NDB form](https://www.oaic.gov.au/privacy/notifiable-data-breaches/report-a-data-breach) | As soon as practicable | ☐ Submitted ☐ Pending |
@@ -977,11 +977,11 @@ Apply these tags to S3 buckets, DynamoDB tables, RDS instances, and other data s
 ### Regulatory References
 
 - [GDPR Full Text (Art. 33 & 34)](https://gdpr-info.eu/art-33-gdpr/)
-- [UK ICO Breach Reporting](https://ico.org.uk/for-organizations/report-a-breach/)
+- [UK ICO Breach Reporting](https://ico.org.uk/for-organisations/report-a-breach/)
 - [CCPA/CPRA Text](https://oag.ca.gov/privacy/ccpa)
 - [HIPAA Breach Notification Rule](https://www.hhs.gov/hipaa/for-professionals/breach-notification/index.html)
 - [PCI-DSS v4.0 Requirement 12.10](https://www.pcisecuritystandards.org/)
-- [PIPEDA Breach Reporting (OPC)](https://www.priv.gc.ca/en/privacy-topics/business-privacy/safeguards-and-breaches/privacy-breaches/respond-to-a-privacy-breach-at-your-business/)
+- [PIPEDA Breach Reporting (OPC)](https://www.priv.gc.ca/en/report-a-concern/report-a-privacy-breach-at-your-organization/report-a-privacy-breach-at-your-business/)
 - [Australian NDB Scheme (OAIC)](https://www.oaic.gov.au/privacy/notifiable-data-breaches)
 - [NIS2 Directive](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive)
 - [DORA Regulation](https://www.digital-operational-resilience-act.com/)
@@ -990,7 +990,7 @@ Apply these tags to S3 buckets, DynamoDB tables, RDS instances, and other data s
 ### Privacy & Data Protection
 
 - [EDPB Guidelines on Personal Data Breach Notification](https://edpb.europa.eu/our-work-tools/our-documents/guidelines/guidelines-92022-personal-data-breach-notification-under_en)
-- [ICO Personal Data Breach Assessment Guidance](https://ico.org.uk/for-organizations/report-a-breach/personal-data-breach-assessment/)
+- [ICO Personal Data Breach Assessment Guidance](https://ico.org.uk/for-organisations/report-a-breach/personal-data-breach-assessment/)
 - [OAIC Data Breach Preparation and Response Guide](https://www.oaic.gov.au/privacy/guidance-and-advice/data-breach-preparation-and-response)
 - [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/)
 

--- a/playbooks/IRP-PersonalDataBreach.md
+++ b/playbooks/IRP-PersonalDataBreach.md
@@ -1,244 +1,1005 @@
-# Incident Response Playbook Template
+# IRP-PersonalDataBreach: Personal Data Breach Response
 
-### Incident Type
+> **Playbook Version:** 2.1
+> **Last Reviewed:** 2026-06-18
+> **Status:** `Active`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-DataAccess](IRP-DataAccess.md) | [IRP-CredCompromise](IRP-CredCompromise.md) | [IRP-InsiderThreat](IRP-InsiderThreat.md) (Coming Soon) | [IRP-Ransomware](IRP-Ransomware.md)
 
-Personal Data Breach
+---
 
-### Introduction
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
 
-This playbook is provided as a template to customers using AWS products and who are building their incident response capability. You should customize this template to suit your particular needs, risks, available tools and work processes.
+---
 
-Security and Compliance is a shared responsibility between you and AWS. AWS is responsible for “Security of the Cloud”, while you are responsible for “Security in the Cloud”. For more information on the shared responsibility model, [please review our documentation](https://aws.amazon.com/compliance/shared-responsibility-model/).
+## Overview
 
-You are responsible for making your own independent assessment of the information in this document. This document: (a) is for informational purposes only, (b) references current AWS product offerings and practices, which are subject to change without notice, and (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. This document is provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
+A personal data breach occurs when personal, regulated, or sensitive data is confirmed to have been accessed, disclosed, altered, or destroyed without authorization. This playbook is activated when an incident — potentially already being handled technically by another playbook — is confirmed to involve personal or regulated data. The focus here is on **regulatory obligation assessment, notification timeline management, evidence preservation for regulators, and individual notification coordination**. Technical containment may already be underway via IRP-CredCompromise, IRP-DataAccess, or IRP-InsiderThreat; this playbook runs in parallel to manage the legal, privacy, and communications workstream that a personal data breach triggers.
 
-## Summary
+### Out of Scope
 
-### This Playbook
+This playbook does **not** cover:
 
-This playbook outlines response steps for Personal Data Breach incidents.  These steps are based on the [NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) that can be used to:
+- **Unauthorized data access without personal data involvement** — If the accessed data is purely operational (infrastructure configs, non-personal telemetry), see [IRP-DataAccess](IRP-DataAccess.md) for technical response only.
+- **Credential compromise as the initial vector** — If you are still investigating the initial access method, see [IRP-CredCompromise](IRP-CredCompromise.md). Return here once personal data involvement is confirmed.
+- **Insider threat investigation and HR coordination** — If the breach was caused by an authorized insider acting outside their role, see [IRP-InsiderThreat](IRP-InsiderThreat.md) (Coming Soon) for the personnel and investigation aspects. This playbook still applies for the notification obligations.
+- **Ransomware with data unavailability** — If personal data has been encrypted (availability breach under GDPR), pivot to [IRP-Ransomware](IRP-Ransomware.md) for technical recovery while continuing notification assessment here.
 
-* Gather evidence
-* Contain and then eradicate the incident
-* Recover from the incident
-* Conduct post-incident activities, including post-mortem and feedback processes
+### Applicable Finding Types
 
-Interested readers may also refer to the [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) which contains additional resources.
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon Macie | `SensitiveData:S3Object/Personal` | HIGH |
+| Amazon Macie | `SensitiveData:S3Object/Financial` | HIGH |
+| Amazon Macie | `SensitiveData:S3Object/Credentials` | CRITICAL |
+| Amazon Macie | `Policy:IAMUser/S3BucketPublic` (on buckets with PII) | CRITICAL |
+| Amazon GuardDuty | `Exfiltration:S3/MaliciousIPCaller` | HIGH |
+| Amazon GuardDuty | `Exfiltration:S3/AnomalousBehavior` | HIGH |
+| Amazon GuardDuty | `UnauthorizedAccess:S3/TorIPCaller` | HIGH |
+| Amazon GuardDuty | `Discovery:S3/AnomalousBehavior` | MEDIUM |
+| AWS Security Hub | S3 bucket findings on data stores containing personal data | HIGH |
+| CloudTrail | `eventName: GetObject` (bulk access to PII-classified buckets) | — |
+| CloudTrail | `eventName: CopyObject` (cross-account copy of personal data) | — |
+| CloudTrail | `eventName: SelectObjectContent` (S3 Select on PII buckets) | — |
+| Third-Party DLP | Data loss prevention alerts indicating PII in transit | HIGH |
+| External Report | Customer/individual report of data misuse or exposure | — |
 
-Once you have customized this playbook to meet your needs, it is important that you test the playbook (e.g., Game Days) and any automation (functional tests), update as necessary to achieve the desired results, and then publish to your knowledge management system and train all responders.
+> 📌 Amazon Macie sensitive data discovery jobs and automated discovery provide the primary signal for personal data classification. See the [Macie finding types reference](https://docs.aws.amazon.com/macie/latest/user/findings-types.html) for the current list.
 
-Note that some of the incident response steps noted in each scenario may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing these scenarios and testing them will help you to determine if additional costs will be incurred. You can use [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be.
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
 
-* * *
+### Severity Classification
 
->  **Warning**
->
-> Besides the procedures outlined in this playbook, your jurisdiction may have requirements and/or legislation about privacy laws (e.g. General Data Protection Regulation (GDPR), California Consumer Privacy Act (CCPA) etc). It may require you to report a security breach and the suspected or confirmed loss or theft of any material or records data. We recommend establishing if this applies to your organization before operationalising this playbook. 
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | Confirmed exfiltration of personal data outside the AWS environment, large-scale breach, or data types with high harm potential (health, financial, biometric, children's data) |
+| **P2 — High** | Confirmed unauthorized access to personal data, data may have left the environment, or regulatory notification deadline is imminent (<24 hours remaining on 72-hour clock) |
+| **P3 — Medium** | Personal data exposure suspected but not confirmed (e.g., bucket was public but access logs show no external downloads), or low-sensitivity data with limited individual count |
+| **P4 — Low** | Policy violation involving personal data stores with no evidence of unauthorized access (e.g., encryption disabled briefly, access logging gap) |
 
-* * *
+---
 
-In reviewing this playbook, you will find steps that involve processes that you may not have in place today. Proactively preparing for incidents means you need the right resource configurations, tools and services in place that allow you to respond to an incident.
+## Part 1 — Prepare
 
-The next section will provide a summary of this incident type, and then cover the five steps (parts 1 - 5) for handling credential compromise.
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
 
-### This Incident Type
+### 1.1 Recommended AWS Service Configurations
 
-A data breach occurs where there is an unauthorised access to or disclosure of personal information, or information is lost in circumstances where unauthorised access or disclosure is likely that could result in harm or inconvenience, such as fraud or identity theft, to an individual.
+The following services each contribute to your ability to detect, scope, and document a personal data breach for regulatory purposes. None are strictly required, but each addresses a specific gap — the more you have enabled, the faster you can determine breach scope and the more defensible your notification decisions will be.
 
-**What is personal data?**
+- [ ] **Amazon Macie** enabled with automated sensitive data discovery running across all S3 buckets — provides continuous identification of where personal data resides and what categories it contains
+- [ ] **Macie custom data identifiers** configured for organization-specific PII patterns (employee IDs, customer numbers, etc.) — extends Macie's detection to organization-specific personal data formats
+- [ ] **Amazon GuardDuty** enabled with S3 protection in all regions — detects exfiltration patterns and unauthorized access to data stores
+- [ ] **AWS CloudTrail** enabled with S3 data events on all buckets containing personal data — the primary evidence source for determining what personal data was accessed and by whom
+- [ ] **CloudTrail management events** enabled with multi-region trail and integrity validation — captures configuration changes to data stores
+- [ ] **AWS Config** enabled with S3-related rules (`s3-bucket-public-read-prohibited`, `s3-bucket-server-side-encryption-enabled`, `s3-bucket-logging-enabled`) — detects misconfigurations that could expose personal data
+- [ ] **Security Hub** enabled with findings aggregation from Macie and GuardDuty — provides unified view of personal data exposure risks
+- [ ] **S3 access logging** enabled on all buckets classified as containing personal data — provides granular access records for scope determination
+- [ ] **S3 Object Lock or versioning** enabled on buckets containing personal data (prevents silent deletion) — protects evidence from tampering
+- [ ] **Amazon Detective** enabled for graph-based investigation of access patterns — reduces time to determine breach scope
+- [ ] **AWS Artifact** access confirmed for compliance documentation retrieval — regulators may request proof of infrastructure security controls
+- [ ] **Data classification tags** applied to all data stores (e.g., `DataClassification: PII`, `DataClassification: PHI`, `DataClassification: PCI`) — enables rapid identification of affected data categories during an incident
 
-All information that can identify an individual is personal data, directly or indirectly. One example is a person’s name, but also things such as login-ID, birthdate, address, email-address, phone number, social-security number, etc. The concept of personal data goes even further: behavioral or performance data of an individual person (like geo-location, performance-metrics, working hours, device IDs, etc.) are all personal data. The rule of thumb is that if you’re thinking about whether some element could be personal data–it usually is! You should verify whether your systems handle or store personal data. If you have internal teams that can help you with this (legal, policy) check with them. If you do not, you can create and document your own definition based on existing definitions today, such as [Article 4 of the GDPR](https://gdpr.eu/article-4-definitions/), or the [definition used in various NIST](https://csrc.nist.gov/glossary/term/PII) Special Publications. Commonly, the personal data referred to in this playbook is known as Personally Identifiable Information (PII).
+> 🤖 **Automation opportunity:** Use Macie automated sensitive data discovery with classification jobs to maintain a continuously updated inventory of where personal data resides. Combine with AWS Config rules to alert when untagged buckets contain Macie-identified PII.
 
-[Art. 4 (1) of GDPR](https://gdpr.eu/article-4-definitions/) defines personal data as:
+> 📌 **Don't have Macie enabled?** Macie can be enabled *during* an incident — it doesn't require historical data to be useful. Enable it on the affected bucket(s) and run an on-demand classification job. Initial results are typically available within 1–4 hours, well within the 72-hour GDPR notification window. If Macie is not available, see [Section 2.2 — Alternative classification approaches](#without-macie-alternative-classification-approaches) for manual methods.
 
-(1) ‘personal data’ means any information relating to an identified or identifiable natural person (‘data subject’); an identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person.
+> 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
-## Incident Response Process
+### 1.2 IAM & Access Prerequisites
 
-### Part 1: Acquire, Preserve, Document Evidence
+Effective incident response for personal data breaches requires having the right access available *before* an incident occurs. Privacy-specific response actions (Macie queries, S3 legal holds, data event exports) use different permissions than typical security response. Pre-provisioning these ensures the Privacy Officer's technical liaison can immediately scope the breach without waiting for access approvals. This aligns with [SEC10-BP05 Pre-provision access](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_provision_access.html) from the AWS Well-Architected Framework.
 
->**Note**
->
-> It is important to exercise caution when collecting information during a PII data breach, as personal information must not be recorded. Instead, focus on collecting contextual information surrounding the breach to aid in the investigation.
+- [ ] **Break-glass IAM role** exists with permissions to: query Macie findings, read S3 access logs, query CloudTrail data events, export GuardDuty findings, and apply S3 Object Lock — pre-tested and documented
+- [ ] **IR team members can assume the break-glass role** with MFA from a trusted account — validate this works at least quarterly
+- [ ] **Access to AWS Security Incident Response console** confirmed (if subscribed)
+- [ ] **Forensic account** available with S3 buckets configured for legal hold (Object Lock in Governance or Compliance mode)
+- [ ] **Pre-approved S3 bucket policy** for emergency access restriction (deny all except IR role) is documented and tested
+- [ ] **Macie classification export permissions** confirmed (IR team can retrieve finding details)
+- [ ] **Privacy Officer has AWS console access** or a designated liaison who can retrieve Macie findings on their behalf
 
-1. You become aware that there has been a possible unintended personal data breach. This information could come via different means, for example:
-    1. PII was accidentally logged or found in the reporting systems, such as application log files, of your security operations.
-    2. An internal ticketing system (the sources of the ticket are varied and could include any of the means below)
-    3. A message from a contractor or third-party service provider
-    4. From an alert in one of your own monitoring systems, either internal or external, to AWS. For example, in AWS, this might include an AWS Config managed rule, AWS CloudTrail via Amazon EventBridge or Amazon CloudWatch Events and Amazon Simple Notification Service (Amazon SNS), via Amazon Macie, Amazon GuardDuty, AWS Security Hub or a similar service.
-    5. From an alert in one of your data loss prevention (DLP) systems
-    6. From a threat actor (for example, requesting a ransom or they will disclose data)
-    7. From a security researcher
-    8. Via an anonymous tip
-    9. From a public news article in the press, on a blog, or in the news
-
-2. Confirm a ticket/case has been raised for the incident. If not, manually raise one.
+### 1.3 Communication & Escalation
 
-3. Determine the sensitivity of the impacted data and record specific AWS resources that were the origin of the breach. It is also essential to determine the number of individuals who were affected by the incident with certainty (*Contextual information is often a key factors in determining the severity of an incident within an Organization*):
-    1. *Nature of personal data:* Your organization's [data classification](https://docs.aws.amazon.com/whitepapers/latest/data-classification/data-classification.html) standards should also define how to handle a Personal Identifiable Information (PII) data breach. The steps or actions you take may vary depending on the sensitivity/classification of the data involved in the breach, you will refer to your data classification and handling policies to determine this. These standards determine the necessary level of protection for different types of information based on their sensitivity. For example, the level of seriousness for a data breach involving sensitive personal health information of an individual would be greater than that of a breach involving publicly available data:
-        1. According to your jurisdiction legal requirements and data classification specifications, it may be necessary to categorize breached data as Personally Identifiable Information (PII) and Publicly Available Information (PAI). Here are few examples:
-            - You should consider the breached personal data as PII unless proven otherwise.
-            - A common example of PAI is information that is readily accessible to the public, such as a person's name, address, and phone number which is listed in a public directory or on social media platforms.
-    2. *Number of AWS resources involved:* Below are a few potential scenarios:
-        1. An Amazon S3 bucket or an Amazon RDS database was compromised, containing sensitive information such as social security numbers, credit card numbers, banking information, or medical records.
-        2. An Amazon Elasticsearch index was lost or compromised, containing personally identifiable information (PII) that should not be publicly accessible.
-        3. An Amazon S3 bucket containing personally identifiable information (PII) was compromised and is publicly available. Here are two example scenarios:
-            -  The bucket was made publicly accessible when it should not have been.
-            -  The bucket may not have been publicly accessible, but data was still exfiltrated due to credential leakage or an incorrectly configured system that accessed the data and made it publicly available.
-    3.  *Number of individual affected:* This information may help your organization to assess the impact on affected individuals and take appropriate measures to mitigate the consequences, such as offering identity theft protection services or providing timely notifications to prevent further harm.
+Personal data breach escalation is time-critical due to hard regulatory deadlines. Unlike purely technical incidents where containment can proceed before leadership is informed, personal data breaches start a notification clock at the moment of awareness. This means the escalation path must be fast, pre-tested, and well understood by all parties. Everyone in this table should know their role *before* an incident occurs.
 
-4. The collection of evidence (AWS CloudTrail logs, AWS Config rules finding etc.) in relation to AWS data services must adhere to a strict chain of custody to ensure the integrity and authenticity of the data as per your jurisdiction legal requirements. Evidence and artifacts can consist of, but aren’t limited to:
-    1. All EC2 instance metadata
-    2. Amazon EBS disk snapshots
-    3. EBS disks streamed to S3
-    4. Memory dumps
-    5. Memory captured through hibernation on the root EBS volume
-    6. CloudTrail logs
-    7. AWS Config rule findings
-    8. Amazon Route 53 DNS resolver query logs
-    9. VPC Flow Logs
-    10. AWS Security Hub findings
-    11. Elastic Load Balancing access logs
-    12. AWS WAF logs
-    13. Custom application logs
-    14. System logs
-    15. Security logs
-    16. Any third-party logs
-
-5. At this point, you may not know the cause of data breach:
-    1. Extrusion by attackers —an attackers penetrated the security perimeter and,gain access to sensitive personal data.
-    2. Insider threats — a malicious insider, or an attacker who has compromised a privileged user accounts, abuses their permissions and attempts to move data outside the organization.
-    3. Unintentional or negligent data exposure — an employees who lose sensitive data in public, provide open Internet access to data, or fail to restrict access per organizational policies.
-
-6. If you are already aware of AWS resources involved (like Amazon S3 or Amazon RDS etc) and , Firstly move to **Part 2** to contain the incident. Once that is done, return here and then move on to step 5. If you have not established which bucket(s) are involved, continue to step 4.
-
-7. If you are *not aware* of the AWS resources involved incident personal data breach within an AWS account, follow these steps:
-    1. Check AWS services used for data storage and processing, such as Amazon S3, Amazon RDS, Amazon DynamoDB, etc.
-    2. Employ the use of internal tools to associate the data with a specific storage location, such as by checking a Configuration Management Database (CMDB).
-    3. Review AWS CloudTrail logs for suspicious activity or unauthorized access.
-    4. Examine the findings of Amazon GuardDuty in either the source AWS account or the central security monitoring account, focusing specifically on any recent findings, regardless of whether AWS resources are implicated in the incident.
-    5. Additionally, review AWS CloudTrail logs to detect any unauthorized access or changes to parameters/secrets in AWS Systems Manager Parameter Store and AWS Secrets Manager. This is important as these services may act as the starting point for managing credentials to access data storage services. To get you started, few examples are:
-        1. [Analyze Security, Compliance, and Operational Activity Using AWS CloudTrail and Amazon Athena](https://aws.amazon.com/blogs/big-data/aws-cloudtrail-and-amazon-athena-dive-deep-to-analyze-security-compliance-and-operational-activity/)
-    6. Please review the access logs for your S3 buckets to identify any unintended or unidentified activity. Here are a few examples of documentation to help you get started:
-        1. [Logging requests using server access logging](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerLogs.html)
-        2. [Identifying access to S3 objects by using CloudTrail](https://docs.aws.amazon.com/AmazonS3/latest/userguide/cloudtrail-request-identification.html#cloudtrail-identification-object-access)
-    7. Utilize the *Advanced Queries* feature of AWS Config to analyze any unintentional or unidentified changes to AWS resources and configurations. To get you started, few example queries mentioned [here.](https://docs.aws.amazon.com/config/latest/developerguide/example-query.html)
-    8. Examine Amazon VPC Flow Logs and AWS WAF logs for any anomalous network activity.
-
-8. If you are *aware* of the AWS resources involved:
-    1. Consider the following steps to identify suspicious activity or unauthorized access in Amazon S3:
-        1. [Review Amazon Macie policy findings related to your S3 data](https://docs.aws.amazon.com/macie/latest/user/findings-types.html#findings-policy-types)
-        2. [Analyze S3 protection in Amazon GuardDuty](https://docs.aws.amazon.com/guardduty/latest/ug/s3-protection.html) 
-    2. For unintended access to an Amazon S3 bucket refer to [this incident response playbook.](https://github.com/aws-samples/aws-incident-response-playbooks/blob/master/playbooks/IRP-DataAccess.md)
-
-9. As previously stated, you maintaining a clear chain of custody is crucial in ensuring the immutability of all evidence. Some of the techniques are mentioned in blog post - [Forensic investigation environment strategies in the AWS Cloud](https://aws.amazon.com/blogs/security/forensic-investigation-environment-strategies-in-the-aws-cloud/). In summary, here are the techniques:
-    1. Snapshots of Amazon EBS disks: The original EBS disks can be snapshotted, shared to a forensics account, converted into a volume, and mounted in read-only mode for offline analysis.
-    2. Manually captured Amazon EBS volumes: Linux tools such as dc3dd can be used to stream the volume to an S3 bucket, along with a hash, and made immutable using an S3 method.
-    3. Artifacts stored in an S3 bucket, such as memory dumps: Object Lock in S3 can prevent deletion or overwriting of objects for a specified duration or permanently. MFA delete requires multi-factor authentication to delete an object permanently. Glacier provides a Vault Lock feature to retain evidence in an immutable state over the long term.
-    4. Disk volumes: Read-only mode can be used for Linux and write-blocker applications for Windows, some of which are specifically designed for forensic use.
-    5. CloudTrail logs: Log file integrity can be validated using CloudTrail's SHA-256 hash and SHA-256 with RSA signing. S3 Object Lock - Governance Mode can be used for protection.
-    6. AWS Systems Manager inventory: By default, metadata on managed instances is stored in an S3 bucket and can be secured using the above methods.
-    7. AWS Config data: Data stored by AWS Config in an S3 bucket can also be protected through the aforementioned methods.
-
-10. Check if there are any open support tickets for the data storage service, and search for connections with any alerts or information related to the incident. Note any perceived effects on end-users, which may encompass but are not limited to:
-    1. Missing data from the storage service
-    2. Unexpected presence of new data in the storage service
-    3. Changes in access settings (such as permissions) of data, especially if they have been made public
-    4. Modified data storage service permissions, access controls, or settings that prevent public access (these may be less noticeable to regular users, but still a possibility)
-
-11. The following are recommendations for internal and external communication regarding a data breach incident, however they may vary based on legal requirements. This example is based on an organization governed by GDPR regulations.
-    1. For internal communication, it is important to quickly gather relevant information and assess the scope and impact of the breach. This information should then be shared with the incident response team and relevant stakeholders within the organization. Regular updates should be provided throughout the investigation process to keep everyone informed.
-    2. For external communication, it is important to consider the privacy rights of individuals whose PII may have been compromised, as well as the organization's obligations under the GDPR or other relevant legislation/protocols for your jurisdiction. In general, organizations are required to report data breaches to relevant authorities within 72 hours and to notify affected individuals without undue delay. 
-
-### Part 2: Contain the Incident
-
-Early identification of unusual actions taken by users or strange network activity is crucial in minimizing the harm caused by incidents involving a PII data breach. To prevent the situation from worsening, it's important to take steps to contain the incident, as well as collaborating with your organization's legal and compliance team on any necessary responses and following the incident response plan outlined. Here are a few examples of containment actions for specific AWS services:
-
-1. In this scenario, PII data breach was in an Amazon S3 bucket. Here are the steps you can take to contain the incident:
-    1. Identify IAM identities with access to AWS resources
-        1. The first step in the process is to identify the IAM identities (which can be either human users or non-human roles) that have access to the AWS resources in question. This is important because it helps to determine the scope of the breach and the extent to which sensitive data has been compromised. Based on this information, you can then take appropriate actions to mitigate the impact of the breach.
-    2. Remove access granting policy for the specific IAM role or user
-        1. In order to revoke S3 access from an IAM role or user, you need to navigate to the specific S3 bucket where the data breach has occurred. This is where the sensitive data was stored and where unauthorized access occurred.
-        2. Once you have navigated to the specific S3 bucket, you need to click on the "Permissions" tab. From there, select the "Bucket Policy" option.
-        3. The next step is to remove the access granting policy for the specific IAM role or user.  Here is a example policy on how to [Managing user access to specific folders.](https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html#example-bucket-policies-folders)This will effectively revoke the access of the IAM role or user to the S3 bucket, preventing further unauthorized access to the sensitive data
-
-2. In this scenario, external vendor accounts have been accessing PII stored in DynamoDB tables through SQS and AWS Lambda. The PII data is encrypted using a KMS key at rest and in transit by application, however, due to a defect in the application, some of the PII information may not have been encrypted properly in transit. To contain this PII data breach, you can take the following actions: 
-    1. Please evaluate the potential business impact of limiting or revoking vendor access to the DynamoDB table, if applicable.
-    2. If it is acceptable to revoke the access of the vendor, you can do so by updating the access policy to remove their permissions to access the impacted DynamoDB tables and the corresponding SQS queue. This will help to prevent any unauthorized access or use of the resources, which will limit the potential impact of the security breach.
-    3. Remove the PII data from the logs of the Lambda function that consumes SQS messages. This helps prevent the sensitive information from being further disclosed or compromised. By using Amazon Comprehend and a Lambda function, you can automatically detect and redact PII data in your S3 objects. Following  is a tutorial on explaing how this can be accomplished:
-        1. [Tutorial: Detecting and redacting PII data with S3 Object Lambda and Amazon Comprehend](https://docs.aws.amazon.com/AmazonS3/latest/userguide/tutorial-s3-object-lambda-redact-pii.html)
-        2. [Sample project to demonstrate how to use AWS SDK for Amazon Comprehend to detect and redact PII data from logs generated by Java applications](https://github.com/aws-samples/comprehend-logging-redact)
-    4. Conduct a table scan to identify all the rows with unencrypted PII data and update/delete columns. 
-
-### Part 3: Eradicate the Incident
-
-First step is to determine the affected resources using log data, resources, and automated tooling and then assess each affected resource to determine the business impact of deletion or restoration. Below is an example of eradication steps that can be taken for a personal data exposure that happened due to wide open security group:
-
-1. Identify the potential immediate cause or causes for the PII exposure at hand:
-    1. Analyze the collected log data, resources, and tooling to determine the source of the exposure.
-    2. Identify if the cause, and then work back through the “5 whys” to get to the root cause https://aws.amazon.com/blogs/mt/why-you-should-develop-a-correction-of-error-coe/.
-
-2. It may be helpful to review the infrastructure deployment pipelines, such as those implemented with CloudFormation via AWS Code Pipeline or Terraform, and the data pipelines to determine which mechanism led to the misconfiguration or misclassification of data injection mechanisms. Are there enough checks and balances in the pipeline? If not, it may be necessary to address this issue.
-
-3. If there are any specific issues that have been identified, take steps to remove any resources or configurations that were identified as the immediate causes. For example:
-    1. If the cause is a misconfigured security group, adjust the security group rules to prevent unauthorized access.
-    2. If the cause is an unauthorized user, revoke their access to the affected resources.
-    3. If the cause is a vulnerability, apply patches or upgrades to fix it.
-    4. There may be other causes, take the appropriate action. 
-
-4. Clean up the environment:
-    1. Delete any PII data that may have been exposed.
-    2. If PII data must be kept, encrypt it to prevent unauthorized access.
-
-5. Restore normal operations:
-    1. Restore permissions and access for authorized users.
-    2. Reconnect systems or resources to the network.
-
-### Part 4: Recover from the Incident
-
-In addition to restoring the service to a stable and reliable state, it is crucial to inform and provide clear guidance to affected users. Here are the steps you can follow:
-
-1. Coordinate with PR and Legal teams:
-    1. Work with your organization's public relations and legal teams to determine the most appropriate approach for communicating with affected users.
-
-1. Update FAQ and Help Center pages:
-    1. Utilize your organization's FAQ and Help Center web pages to provide clear and concise information to affected users.
-    1. Ensure that the FAQ and Help Center web page are updated regularly with the latest information regarding the incident, including any measures that users can take to safeguard themselves. Here are some sample guidelines that you can provide to your affected external customers in case of identity theft via your application:
-        1. *Verify the breach*: Confirm that your personal information has been exposed in the data breach by checking our help centre website. 
-        2. *Secure your accounts*: Change passwords for any accounts that use the breached information, such as email and financial accounts, and enable two-factor authentication.
-        3. *Monitor your accounts*: Regularly monitor your accounts associated with the breached information for any unauthorized activities.
-        4. *Place a fraud alert*: Consider placing a fraud alert on your credit report to alert lenders and banks to check with you before opening new accounts.
-        5. *Consider credit monitoring:* Consider enrolling in a credit monitoring service to receive alerts about any changes or suspicious activity on your credit report.
-        6. *Report the breach*: Report the data breach to relevant government agencies if applicable. 
-        7. *Stay vigilant*: Be mindful of phishing scams and other attempts to steal your information, and take steps to protect your information going forward.
-
-1. Provide timely information:
-    1. Make sure that information is updated in a timely manner to keep affected users informed of the latest developments.
-    2. Ensure that the information provided is accurate and easy to understand.
-
-By taking these steps, you can help affected users to stay informed and feel confident that their information and interests are being protected during an incident.
-
-### Part 5: Post-Incident Activity
-
->**Note**
->
-> It is important to contact legal counsel **early** to determine if public and individual communication needs to be initiated. Legal counsel can provide guidance on the specific legal requirements and obligations associated with the notification of personal data breaches, including any applicable laws, regulations, and industry standards.
-
-Once you have removed the affected resources, it's recommended that you perform a security assessment of your AWS account. This assessment can be accomplished by utilizing AWS Config rules, open-source tools like Prowler and ScoutSuite, or other providers. Furthermore, we suggest conducting vulnerability scans on your publicly accessible resources to identify any lingering risks.
-
-In the aftermath of a personal data breach, it is critical to conduct a comprehensive post-incident review to identify areas for improvement and prevent similar incidents from happening in the future. The following post-incident activities can be performed in accordance with the correction of error (COE) concept that is discussed in the following links:
-
-[Why you should develop a correction of error (COE)](https://aws.amazon.com/blogs/mt/why-you-should-develop-a-correction-of-error-coe/)
-[Correction of Error (COE)](https://wa.aws.amazon.com/wat.concept.coe.en.html)
-
-1. Review the incident: Perform a thorough review of the incident, including the causes, severity, and impact. This information will be used to determine the effectiveness of the incident response plan and identify areas for improvement.
-
-2. Document lessons learned: Document lessons learned from the incident and use this information to update the incident response plan. This information should include details about the attack vector, the methods used by the attacker, and any other relevant information.
-
-3. Update the incident response plan: Based on the lessons learned, update the incident response plan to reflect any changes or improvements that should be made to the incident response process.
-
-4. Perform a root cause analysis: Conduct a root cause analysis to determine the underlying causes of the incident and to identify any additional areas for improvement.
-
-5. Update policies and procedures: Based on the results of the root cause analysis, update policies and procedures to ensure that the incident response plan is aligned with best practices and regulatory requirements.
-
-6. Implement corrective actions: Implement any necessary corrective actions to prevent similar incidents from happening in the future.
+> 📋 Do not include names. Use roles only. Maintain a separate, access-controlled contact list.
+
+| Role | Responsibility | When to Engage |
+|---|---|---|
+| IR Lead | Overall incident coordination, technical workstream | Immediately upon incident detection |
+| Privacy Officer / DPO | Regulatory obligation assessment, notification decisions, DPA liaison | Within 1 hour of personal data involvement confirmed |
+| Legal Counsel | Legal privilege, notification content review, regulatory strategy | When notification obligation is likely (P1/P2) or within 4 hours of awareness |
+| Account Owner | Business context, data inventory knowledge | When scope of affected data stores needs clarification |
+| Communications Lead | Individual notification drafting, media response (if required) | When notification decision is made (typically 12–24 hours into incident) |
+| Customer Support Lead | Individual inquiry handling post-notification | 24–48 hours before individual notifications are sent |
+| AWS CIRT | Engage via AWS Support case or Security Incident Response service (P1/P2, if available) | P1: Immediately. P2: Within 4 hours. P3/P4: As needed for evidence gathering. |
+
+**Escalation path:**
+
+1. **Personal data involvement confirmed** → IR Lead documents the exact timestamp (this starts the notification clock)
+2. **Within 1 hour:** Privacy Officer / DPO notified — this is a hard internal SLA, non-negotiable
+3. **Within 2 hours:** IR Lead + Privacy Officer jointly assess severity using the classification table above
+4. **P1/P2:** Legal Counsel engaged immediately; AWS CIRT engaged; Communications Lead placed on standby
+5. **P3/P4:** Privacy Officer assesses notification obligation; IR Lead manages technical response via parallel playbook
+6. **Within 24 hours:** Notification decision made and documented (notify or documented justification for non-notification)
+
+> ⚠️ **Critical:** The Privacy Officer / DPO must be notified within **1 hour** of personal data involvement being confirmed. The 72-hour GDPR notification clock starts at awareness — delays in internal escalation directly consume the notification window.
+
+> 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — pre-identify all stakeholders (including legal, privacy, and communications) and establish clear escalation paths before an incident occurs.
+
+### 1.4 Game Day Guidance
+
+Personal data breach scenarios are uniquely challenging because they require coordination across technical, legal, privacy, and communications workstreams — often with hard regulatory deadlines. Testing this playbook validates not just technical capability but also the speed of internal escalation, the accuracy of your data inventory, and the readiness of notification templates. Include your Privacy Officer and Legal Counsel in exercises.
+
+Recommended testing cadence: **Semi-annually** (this is a P1-capable scenario with hard regulatory deadlines).
+
+Suggested tabletop scenario:
+> *"Amazon Macie has generated a finding showing that an S3 bucket containing 50,000 customer records (names, email addresses, dates of birth, and Canadian Social Insurance Numbers) was accessed by a cross-account IAM role belonging to a third-party analytics vendor. The access occurred 6 hours ago. CloudTrail shows 12,000 GetObject calls from this role in a 30-minute window. Your customers span the EU, Canada, Australia, and California. You have 66 hours remaining on the GDPR 72-hour notification clock. Determine: (1) Was data exfiltrated? (2) Which regulators must be notified? (3) What is the notification content for each jurisdiction?"*
+
+**Practice resources (no paid service or support plan required):**
+
+- [Data Discovery and Classification with Amazon Macie](https://catalog.workshops.aws/data-discovery/en-US) — hands-on workshop covering S3 data scanning, custom data identifiers, Macie classification jobs, and Security Hub integration for understanding data exposure.
+- [AWS Foundational Security, Identity and Governance Workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/05554d54-07cc-483e-b810-d69f7d99b2ab/en-US) — demos and hands-on practice with security controls, governance frameworks, and compliance checks for AWS environments.
+- [Data Perimeter Workshop](https://catalog.workshops.aws/workshops/a11f0f32-cc23-4c95-b243-43c53bdc7177/en-US) — five lab modules teaching data perimeter controls for data loss prevention, including identity-based policies, resource-based policies, and VPC endpoint policies to restrict data access to authorized users from expected network locations.
+
+> 📖 **Reference:** [SEC10-BP04 Develop and test security incident response playbooks](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_develop_test_playbooks.html) — regularly test playbooks through tabletop exercises, simulations, and game days to verify processes work under time pressure.
+
+---
+
+## Part 2 — Detect & Analyze
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyze)
+> **Goal:** Confirm personal data involvement, determine scope, assess exfiltration, and establish notification obligations.
+
+### 2.1 Initial Triage Questions
+
+These questions determine whether this playbook is activated and at what priority. The first three are activation gates — if any is "No," handle the incident with the appropriate technical playbook only. The scope assessment questions feed directly into the Privacy Officer's notification obligation assessment.
+
+Answer these quickly to determine scope and priority. The first three questions determine whether this playbook is activated.
+
+**Activation questions (all must be YES to proceed with this playbook):**
+
+- [ ] Has an unauthorized access, disclosure, or loss of data been confirmed or strongly suspected?
+- [ ] Does the affected data store contain personal data (PII, PHI, PCI, financial, biometric)?
+- [ ] Is the data identifiable to specific individuals (directly or through combination with other available data)?
+
+**Scope assessment questions:**
+
+- [ ] What categories of personal data are involved? (Names, emails, health records, financial data, government IDs, biometric data, children's data)
+- [ ] How many individuals are potentially affected?
+- [ ] In which jurisdictions do the affected individuals reside? (Determines which regulations apply)
+- [ ] Was the data encrypted at rest? Was the encryption key also compromised?
+- [ ] Has data left the AWS environment? (Check VPC Flow Logs, S3 server access logs, CloudTrail)
+- [ ] Is the technical containment already handled by another playbook? (If yes, this playbook focuses on regulatory/notification workstream)
+- [ ] When did the organization first become aware of the breach? (This starts the notification clock)
+- [ ] Is there a Record of Processing Activities (ROPA) that documents this data processing?
+- [ ] Was a Data Protection Impact Assessment (DPIA) conducted for this processing activity?
+
+**If personal data is confirmed involved AND data may have left the environment → P1 immediately. Notify Privacy Officer within 1 hour.**
+
+### 2.2 Data Classification & Sensitivity Assessment
+
+> `[Privacy Officer]` leads this assessment with support from `[IR Lead]` for technical evidence.
+
+Use Amazon Macie findings and your organization's data classification framework to determine what was exposed.
+
+**Data sensitivity tiers (highest to lowest regulatory impact):**
+
+| Tier | Data Types | Regulatory Implications |
+|---|---|---|
+| **Tier 1 — Special Category** | Health/medical (PHI), biometric, genetic, racial/ethnic origin, political opinions, religious beliefs, sexual orientation, children's data | GDPR Art. 9, HIPAA, mandatory individual notification in most jurisdictions |
+| **Tier 2 — High Sensitivity** | Government identifiers (SSN, SIN, TFN, passport), financial account numbers, payment card data (PAN), login credentials | PCI-DSS, identity theft risk, credit monitoring obligations likely |
+| **Tier 3 — Standard PII** | Names, email addresses, phone numbers, physical addresses, dates of birth, employment information | Standard notification obligations per jurisdiction |
+| **Tier 4 — Low Sensitivity** | Business contact information, publicly available information, pseudonymized data (where key not compromised) | Notification may not be required (assess per jurisdiction) |
+
+**Amazon Macie data identifiers to check:**
+
+| Macie Managed Data Identifier | Maps to Tier |
+|---|---|
+| `AUSTRALIA_TAX_FILE_NUMBER`, `CANADA_SOCIAL_INSURANCE_NUMBER`, `UK_NATIONAL_INSURANCE_NUMBER` | Tier 2 |
+| `CREDIT_CARD_NUMBER`, `BANK_ACCOUNT_NUMBER` | Tier 2 |
+| `AWS_CREDENTIALS`, `OPENSSH_PRIVATE_KEY` | Tier 2 |
+| `USA_SOCIAL_SECURITY_NUMBER`, `USA_PASSPORT_NUMBER` | Tier 2 |
+| `PHONE_NUMBER`, `EMAIL_ADDRESS`, `NAME` | Tier 3 |
+| `DATE_OF_BIRTH`, `ADDRESS` | Tier 3 |
+| Custom data identifiers (organization-specific) | Per classification |
+
+> 📌 Run a Macie classification job on the affected bucket(s) if automated discovery has not recently scanned them. Results typically available within 1–4 hours depending on data volume.
+
+#### Without Macie: Alternative Classification Approaches
+
+If Amazon Macie was not enabled prior to the incident, you can still determine data classification — it requires more manual effort but is achievable within notification timelines.
+
+**Option 1: Enable Macie now and run an on-demand classification job (recommended)**
+
+Macie can be enabled during an active incident. It does not require historical data or prior configuration to classify current bucket contents. Enable Macie, create a classification job scoped to the affected bucket(s), and results will be available within 1–4 hours. This is still the fastest path to defensible classification.
+
+**Option 2: Manual classification using available information**
+
+If Macie is not an option (organizational constraints, time pressure, or the data has already been deleted):
+
+1. **Check object key naming patterns** — filenames often indicate content type (e.g., `customer-export.csv`, `user-data/`, `pii-backup-20260501.json.gz`). This provides a quick initial signal.
+2. **Review application documentation** — check data dictionaries, database schemas, API documentation, or architecture diagrams that describe what the application stores in the affected bucket.
+3. **Ask the data owner directly** — the application team or data owner typically knows what data is stored and its sensitivity. This is often the fastest path during an incident.
+4. **Sample and inspect** — download a small sample of objects (2–3 files) to a forensic environment and manually review contents for personal data categories. Document what you find.
+5. **Check existing data classification tags** — if `DataClassification` tags are applied to the bucket or objects, use those as the starting point for sensitivity assessment.
+6. **Review CloudTrail object keys** — even without Macie, CloudTrail data events show which specific object keys were accessed. Object key names may indicate data type.
+
+**Regulatory posture without Macie:**
+
+> ⚠️ If you cannot definitively determine whether accessed data contains personal information, the conservative regulatory approach is to assume it does. Under GDPR, the inability to exclude personal data involvement is itself a factor that supports notification. Document your classification methodology and any limitations — regulators evaluate the reasonableness of your assessment, not whether you had perfect tooling.
+
+### 2.3 Evidence Documentation
+
+> ⚠️ **Evidence preservation is critical for regulatory investigations.** Regulators may request evidence months after the incident. Apply legal hold immediately. Failure to preserve evidence can result in adverse inferences and increased regulatory penalties.
+
+| Evidence Type | How to Collect | Where to Store |
+|---|---|---|
+| Macie sensitive data findings | Macie console → Findings → Export JSON | Forensic S3 bucket (Object Lock) |
+| Macie classification job results | Macie console → Jobs → Results | Forensic S3 bucket (Object Lock) |
+| S3 server access logs (affected buckets) | Copy from logging bucket for relevant time window | Forensic S3 bucket (Object Lock) |
+| CloudTrail data events (S3 GetObject, etc.) | Athena query (see resources file) | Forensic S3 bucket (Object Lock) |
+| CloudTrail management events | Athena query for IAM/S3 configuration changes | Forensic S3 bucket (Object Lock) |
+| GuardDuty exfiltration findings | `aws guardduty get-findings --detector-id ... --finding-ids ...` | Forensic S3 bucket (Object Lock) |
+| VPC Flow Logs (if data accessed via EC2/Lambda) | CloudWatch Logs export or S3 copy | Forensic S3 bucket (Object Lock) |
+| S3 bucket policy history | AWS Config timeline for the bucket resource | IR ticket |
+| IAM policy of accessing principal | `aws iam get-policy-version` + `aws iam list-attached-*-policies` | IR ticket |
+| Data inventory / ROPA extract | Internal privacy management system | IR ticket (restricted access) |
+| Notification clock start documentation | Screenshot/log of when awareness occurred | IR ticket |
+
+**Initiate legal hold immediately:**
+
+```bash
+# Apply Object Lock legal hold to forensic evidence bucket
+aws s3api put-object-legal-hold \
+  --bucket forensic-evidence-bucket \
+  --key "incidents/PDB-2026-001/" \
+  --legal-hold Status=ON
+
+# Confirm Object Lock is enabled on the forensic bucket
+aws s3api get-object-lock-configuration \
+  --bucket forensic-evidence-bucket
+```
+
+**Investigation queries for evidence collection:**
+
+The companion resource file [`resources/athena-queries-personal-data-breach.sql`](resources/athena-queries-personal-data-breach.sql) contains the full set of Athena queries for personal data breach investigation, including:
+
+- All S3 data access events on PII-classified buckets (Section 1.1–1.4)
+- Cross-account access detection
+- Bulk download pattern detection (exfiltration indicators)
+- Macie finding correlation with CloudTrail access events
+- GuardDuty and Macie CLI export commands
+
+Use these queries to build a complete evidence package for regulatory submissions.
+
+### 2.4 Determining Data Access Scope
+
+> `[IR Lead]` performs technical analysis. Results feed into `[Privacy Officer]`'s notification assessment.
+
+**Step 1: Identify what was accessed**
+
+Use CloudTrail data events to determine exactly which objects containing personal data were accessed. The Privacy Officer needs to understand what questions are being answered and what the results mean — this analysis is integral to the notification obligation assessment.
+
+> 📌 **Without Macie:** If Macie findings are not available to identify which objects contain PII, use the alternative approaches from [Section 2.2](#without-macie-alternative-classification-approaches) to determine which accessed objects are likely to contain personal data. Replace the Macie-derived object key list with keys identified through manual classification, data owner consultation, or naming pattern analysis.
+
+Run the following queries from [`resources/athena-queries-personal-data-breach.sql`](resources/athena-queries-personal-data-breach.sql):
+
+| Query | What It Answers | Feeds Into |
+|---|---|---|
+| **1.5 — Macie finding correlation** | Were objects *confirmed by Macie to contain PII* actually accessed during the incident window? | Notification obligation: confirms personal data was accessed, not just that the bucket was accessed |
+| **2.2 — Data volume determination** | How many unique objects were accessed and how much data was transferred? | GDPR Art. 33: "approximate number of records" field in regulator notification |
+| **1.3 — Individual count estimation** | How many individuals are potentially affected? | All jurisdictions: notification scope and individual notification feasibility |
+| **1.2 — Cross-account access** | Was data accessed from an account outside the organization? | Indicates disclosure to a third party — stronger notification trigger |
+
+**Step 2: Determine if data left the AWS environment**
+
+This is the critical question for notification obligations. Data accessed within AWS (e.g., by another AWS service or account) may have different risk implications than data confirmed exfiltrated to an external location.
+
+Indicators of exfiltration:
+- GuardDuty `Exfiltration:S3/MaliciousIPCaller` or `Exfiltration:S3/AnomalousBehavior` findings
+- CloudTrail `GetObject` calls from IP addresses outside known AWS ranges
+- VPC Flow Logs showing large outbound data transfers to unknown IPs
+- S3 replication configured to an external account
+- `CopyObject` calls to a bucket in an unknown account
+- CloudTrail `PutObject` to a bucket outside the organization (cross-account)
+
+Run query **2.3 — Exfiltration indicators** from the resources file. This identifies `GetObject` calls from non-private IP addresses — the single most important indicator for notification decisions.
+
+> 📌 **Important:** Even if you cannot confirm exfiltration, if data was accessed by an unauthorized party, most regulations treat this as a breach requiring notification. The inability to prove data *did not* leave the environment is itself a risk factor.
+
+### 2.5 Notification Obligation Assessment
+
+> `[Privacy Officer]` leads with `[Legal Counsel]` support. Complete within **24 hours** of awareness to preserve notification timeline options.
+
+For each jurisdiction where affected individuals reside, assess notification obligations:
+
+| Regulation | Jurisdiction | Trigger Met? | Notification Deadline | Authority to Notify | Notes |
+|---|---|---|---|---|---|
+| **GDPR Art. 33/34** | EU/EEA | ☐ Yes ☐ No ☐ TBD | 72 hours to DPA; without undue delay to individuals (if high risk) | Lead Supervisory Authority (DPA) | Clock starts at awareness. Incomplete notification acceptable with follow-up. |
+| **UK GDPR / DPA 2018** | United Kingdom | ☐ Yes ☐ No ☐ TBD | 72 hours to ICO | Information Commissioner's Office (ICO) | Separate from EU GDPR post-Brexit. |
+| **PIPEDA** | Canada | ☐ Yes ☐ No ☐ TBD | "As soon as feasible" to OPC and individuals | Office of the Privacy Commissioner (OPC) | Trigger: real risk of significant harm (RROSH). |
+| **CCPA/CPRA** | California, US | ☐ Yes ☐ No ☐ TBD | "Most expedient time possible" | California AG + affected individuals | Applies to unencrypted personal information. |
+| **HIPAA** | US (if PHI) | ☐ Yes ☐ No ☐ TBD | 60 days to HHS; without unreasonable delay to individuals | HHS OCR + individuals; media if >500 | Only if unsecured PHI. |
+| **PCI-DSS** | Global (if PAN) | ☐ Yes ☐ No ☐ TBD | Immediately to payment brands | Acquiring bank + card brands | Forensic investigation by PCI QSA may be required. |
+| **Australian NDB** | Australia | ☐ Yes ☐ No ☐ TBD | "As soon as practicable" (30-day assessment window) | OAIC + affected individuals | Trigger: likely to result in serious harm. |
+| **NIS2** | EU (if essential/important entity) | ☐ Yes ☐ No ☐ TBD | Early warning 24 hours; notification 72 hours; final report 1 month | National CSIRT or competent authority | Applies to essential and important entities. |
+| **DORA** | EU (if financial entity) | ☐ Yes ☐ No ☐ TBD | Initial 4 hours; intermediate 72 hours; final 1 month | National financial regulator | Major ICT-related incident classification required. |
+| **SEC Rules** | US (if public company) | ☐ Yes ☐ No ☐ TBD | 4 business days after materiality determination | SEC (Form 8-K) | Materiality assessment required. |
+
+> ⚠️ **The clock starts at awareness, not confirmation.** For GDPR, "awareness" means when you have a reasonable degree of certainty that a breach has occurred. Do not delay notification to complete investigation — submit an incomplete initial notification and follow up.
+
+### 2.6 Severity Determination
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Personal data confirmed exfiltrated outside AWS, large individual count, or high-sensitivity data (Tier 1/2) | P1 |
+| Personal data accessed by unauthorized party, exfiltration unclear, notification deadline approaching | P2 |
+| Personal data exposure suspected (e.g., bucket was public) but no confirmed access | P3 |
+| Policy violation on personal data store, no evidence of unauthorized access | P4 |
+
+### 2.7 AWS Security Incident Response Service
+
+> 📌 **If your organization has the AWS Security Incident Response service enabled, or has AWS Support, you can request assistance from the AWS Customer Incident Response Team (CIRT).**
+
+**P1 — Critical:** Engage AWS immediately.
+
+- **If you have the AWS Security Incident Response service enabled:** Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose the appropriate request type — **Active Security Incident** for urgent incident response support, or **Investigations and Inquiries** for log analysis support, secondary confirmation, or general security posture questions.
+- **If you need assistance from AWS CIRT:** Open a support case with Critical severity and request assistance from the AWS Customer Incident Response Team (CIRT). Include relevant finding IDs and a summary of what you have observed.
+
+**P2 — High:** Engage AWS within 4 hours of awareness.
+
+- AWS CIRT can assist with evidence gathering and scope determination that directly supports your notification obligation assessment. They can help determine whether data left the AWS environment — often the critical question for notification decisions.
+
+**P3 — Medium:** Engage AWS as needed for evidence gathering support.
+
+- Even for lower-severity incidents, AWS CIRT can assist with CloudTrail analysis, Macie interpretation, and evidence documentation that supports regulatory submissions. Consider engaging if your team lacks experience with Athena queries against CloudTrail data events.
+
+> 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
+
+> The AWS Security Incident Response service can assist with evidence gathering and documentation that supports regulatory notification requirements. They do not provide legal advice on notification obligations.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Stop further data access, preserve evidence for regulatory investigation, initiate legal hold, and document the notification clock.
+
+> 📌 **Note:** Technical containment of the underlying incident (credential revocation, network isolation, etc.) may already be handled by the parallel technical playbook (IRP-CredCompromise, IRP-DataAccess, IRP-InsiderThreat). This section focuses on containment actions specific to the personal data breach workstream.
+
+### 3.1 Containment Decision
+
+```
+Is personal data still actively being accessed or exfiltrated?
+│
+├── YES (active access ongoing)
+│     └── Coordinate with technical IR playbook for immediate access revocation
+│           Then proceed to 3.2 for evidence preservation
+│
+└── NO (access has stopped or technical containment already applied)
+      └── Proceed directly to 3.2 — focus on evidence preservation and clock documentation
+```
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates technical actions. `[Privacy Officer]` coordinates regulatory actions. Both run in parallel.
+
+**Step 1: Stop further data access (coordinate with technical playbook)**
+
+If not already handled by the parallel technical playbook, restrict access to affected data stores immediately:
+
+```bash
+# Emergency: Apply deny-all bucket policy (preserves data, blocks all access)
+aws s3api put-bucket-policy --bucket customer-pii-bucket --policy '{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "EmergencyDenyAll",
+    "Effect": "Deny",
+    "Principal": "*",
+    "Action": "s3:*",
+    "Resource": [
+      "arn:aws:s3:::customer-pii-bucket",
+      "arn:aws:s3:::customer-pii-bucket/*"
+    ],
+    "Condition": {
+      "StringNotLike": {
+        "aws:PrincipalArn": [
+          "arn:aws:iam::123456789012:role/IncidentResponseRole",
+          "arn:aws:iam::123456789012:role/ForensicPreservationRole"
+        ]
+      }
+    }
+  }]
+}'
+```
+
+> ⚠️ **Warning:** This will break any applications reading from this bucket. Obtain `[Account Owner]` authorization before applying in production unless active exfiltration is confirmed (P1).
+
+**Step 2: Preserve evidence under legal hold**
+
+```bash
+# Enable Object Lock on forensic bucket (if not already configured)
+# Note: Object Lock must be enabled at bucket creation — use a pre-configured forensic bucket
+
+# Copy affected S3 access logs to forensic bucket with legal hold
+aws s3 cp s3://access-logs-bucket/customer-pii-bucket/ \
+  s3://forensic-evidence-bucket/incidents/PDB-2026-001/s3-access-logs/ \
+  --recursive
+
+# Apply legal hold to all preserved evidence
+aws s3api put-object-legal-hold \
+  --bucket forensic-evidence-bucket \
+  --key "incidents/PDB-2026-001/" \
+  --legal-hold Status=ON
+```
+
+**Step 3: Preserve CloudTrail logs**
+
+```bash
+# Export relevant CloudTrail logs to forensic bucket
+# Use Athena to query and export, or copy raw log files
+aws s3 cp s3://cloudtrail-logs-bucket/AWSLogs/123456789012/CloudTrail/ \
+  s3://forensic-evidence-bucket/incidents/PDB-2026-001/cloudtrail/ \
+  --recursive \
+  --exclude "*" \
+  --include "*2026-05-2*"
+```
+
+**Step 4: Document the notification clock**
+
+> `[Privacy Officer]` owns this step. This is a legal record that will be reviewed by regulators.
+
+The notification clock documentation must be created within 1 hour of personal data involvement being confirmed. This record is your primary defense against claims of delayed notification.
+
+Document the following in your incident management system:
+
+1. **Exact timestamp (UTC)** when the organization became aware of the personal data breach
+2. **How** awareness was achieved (Macie finding, GuardDuty alert, customer report, etc.) — include the finding ID or alert reference
+3. **Who** was first aware (role, not name) and who made the determination that personal data was involved
+4. **What** was known at the time of awareness — be specific about what was confirmed vs. suspected
+5. **Notification clock deadlines** calculated from the awareness timestamp (e.g., GDPR 72h = [specific UTC timestamp])
+
+This record establishes the start of the notification clock for GDPR (72 hours), NIS2 (24 hours early warning), and other time-bound obligations.
+
+**Step 5: Initiate legal hold on all relevant systems**
+
+> `[Legal Counsel]` authorizes. `[IR Lead]` implements.
+
+Legal hold prevents the routine deletion or modification of evidence that may be required by regulators months or years after the incident. Implement legal hold across all systems that may contain evidence of the breach scope, timeline, or response actions.
+
+Place legal hold on:
+- [ ] All S3 access logs for affected buckets (full retention period)
+- [ ] CloudTrail logs for affected accounts (full retention period)
+- [ ] VPC Flow Logs for affected VPCs
+- [ ] Application logs that may contain access records
+- [ ] Email and messaging records related to the incident
+- [ ] Macie findings and classification job results
+- [ ] GuardDuty findings related to the incident
+- [ ] Any backup or replica of the affected data
+
+For S3-stored evidence, apply Object Lock legal hold:
+
+```bash
+# Apply legal hold to preserved evidence (run after copying to forensic bucket)
+aws s3api put-object-legal-hold \
+  --bucket forensic-evidence-bucket \
+  --key "incidents/PDB-2026-001/" \
+  --legal-hold Status=ON
+```
+
+Notify all system administrators that legal hold is in effect and no logs or data within the hold scope may be deleted, modified, or allowed to expire through normal retention policies.
+
+### 3.3 Document Containment Actions
+
+After containment, document and confirm the following before any data modification or deletion. This checklist serves as both an operational gate and a regulatory evidence record — regulators will ask what containment measures were taken and when.
+
+- [ ] All S3 access logs for affected buckets copied to forensic bucket with Object Lock
+- [ ] CloudTrail logs (management + data events) preserved for the full incident window
+- [ ] Macie findings exported and preserved
+- [ ] GuardDuty findings exported and preserved
+- [ ] VPC Flow Logs exported (if applicable)
+- [ ] Legal hold applied to all forensic evidence
+- [ ] CloudTrail log integrity validation confirmed on preserved logs
+- [ ] Chain of custody documented (who collected what, when, how)
+- [ ] Notification clock start time formally documented and communicated to Privacy Officer
+
+---
+
+## Part 4 — Eradicate & Recover
+
+> **CSF 2.0 Function:** Respond (Eradicate) · Recover
+> **Goal:** Confirm the full scope of personal data affected, determine notification content, prepare regulatory submissions, and implement individual protections.
+
+> 📌 **Note:** Technical eradication (removing threat actor access, closing vulnerabilities) is handled by the parallel technical playbook. This section focuses on the regulatory, notification, and individual protection workstream.
+
+### 4.1 Full Scope Determination
+
+> `[IR Lead]` provides technical findings. `[Privacy Officer]` interprets for regulatory purposes.
+
+Before preparing notifications, confirm the following with as much precision as possible:
+
+**Data scope:**
+- [ ] Exact data categories involved (names, emails, government IDs, health data, financial data, etc.)
+- [ ] Number of unique individuals affected (or best estimate with confidence range)
+- [ ] Jurisdictions of affected individuals (determines which regulations apply)
+- [ ] Time period of exposure (when did unauthorized access begin and end?)
+- [ ] Whether data was encrypted and whether encryption keys were also compromised
+- [ ] Whether data has been confirmed exfiltrated or only accessed
+
+**Individual impact assessment:**
+- [ ] What is the likely harm to individuals? (Identity theft, financial fraud, discrimination, reputational damage)
+- [ ] Are vulnerable populations affected? (Children, patients, employees)
+- [ ] Can affected individuals be individually identified for notification?
+- [ ] What protective measures can be offered? (Credit monitoring, identity protection, password resets)
+
+### 4.2 Notification Content Preparation
+
+> `[Privacy Officer]` leads content preparation. `[Legal Counsel]` reviews. `[Communications Lead]` finalizes language.
+
+**Regulator notification content (GDPR Art. 33 template elements):**
+
+Each regulatory notification should include (adapt per jurisdiction requirements):
+
+1. **Nature of the breach** — What happened, categories of data, approximate number of individuals
+2. **Contact details** — DPO or privacy contact point name and details
+3. **Likely consequences** — Assessment of potential harm to individuals
+4. **Measures taken** — Actions taken to address the breach and mitigate harm
+5. **Measures to mitigate** — Steps individuals can take to protect themselves
+
+**Individual notification content (GDPR Art. 34 template elements):**
+
+1. **Clear, plain language description** of what happened
+2. **What personal data was involved** (be specific — "your name, email address, and date of birth")
+3. **What we are doing about it** (containment, investigation, remediation)
+4. **What you can do** (change passwords, monitor accounts, credit monitoring enrollment)
+5. **Contact information** for questions (dedicated support line/email)
+6. **Apology and commitment** to preventing recurrence
+
+> ⚠️ **Legal privilege:** Draft notifications under legal privilege until finalized. Mark all drafts as "PRIVILEGED AND CONFIDENTIAL — PREPARED AT THE DIRECTION OF LEGAL COUNSEL."
+
+### 4.3 Regulatory Submission Preparation
+
+> `[Privacy Officer]` prepares submissions. `[Legal Counsel]` approves before filing.
+
+**For each applicable jurisdiction:**
+
+| Jurisdiction | Submission Method | Key Deadlines | Status |
+|---|---|---|---|
+| EU/EEA (GDPR) | DPA online portal (varies by member state) | 72 hours initial; follow-up as needed | ☐ Submitted ☐ Pending |
+| UK (ICO) | [ICO breach reporting tool](https://ico.org.uk/for-organizations/report-a-breach/) | 72 hours | ☐ Submitted ☐ Pending |
+| Canada (PIPEDA) | [OPC breach report form](https://www.priv.gc.ca/en/report-a-concern/report-a-privacy-breach-at-your-organization/) | As soon as feasible | ☐ Submitted ☐ Pending |
+| California (CCPA) | [California AG breach reporting](https://oag.ca.gov/privacy/databreach/reporting) | Most expedient time possible | ☐ Submitted ☐ Pending |
+| Australia (NDB) | [OAIC NDB form](https://www.oaic.gov.au/privacy/notifiable-data-breaches/report-a-data-breach) | As soon as practicable | ☐ Submitted ☐ Pending |
+| US (HIPAA) | [HHS breach portal](https://ocrportal.hhs.gov/ocr/breach/wizard_breach.jsf) | 60 days | ☐ Submitted ☐ Pending |
+| US (SEC) | Form 8-K filing | 4 business days after materiality determination | ☐ Submitted ☐ Pending |
+
+**AWS Artifact for compliance documentation:**
+
+Use [AWS Artifact](https://console.aws.amazon.com/artifact/) to retrieve:
+- AWS SOC 2 Type II report (demonstrates AWS infrastructure security controls)
+- AWS PCI-DSS Attestation of Compliance (if PCI data involved)
+- AWS ISO 27001 certificate
+- AWS HIPAA compliance documentation (if PHI involved)
+
+These documents may be requested by regulators to demonstrate the security posture of the infrastructure hosting the affected data.
+
+### 4.4 Individual Notification & Protection
+
+> `[Communications Lead]` manages notification delivery. `[Customer Support Lead]` manages incoming inquiries.
+
+**Notification delivery:**
+- [ ] Individual notification content finalized and approved by Legal
+- [ ] Notification delivery method determined (email, postal mail, public notice)
+- [ ] Dedicated support channel established (phone line, email address, FAQ page)
+- [ ] Customer support team briefed on incident details and approved responses
+- [ ] Notification sent to all identifiable affected individuals
+- [ ] Delivery confirmation tracked (email delivery receipts, postal tracking)
+
+**Individual protection measures (if applicable):**
+- [ ] Credit monitoring service enrolled for affected individuals (if government IDs or financial data exposed)
+- [ ] Identity protection service offered (if Tier 1 or Tier 2 data exposed)
+- [ ] Password reset forced for affected accounts (if credentials exposed)
+- [ ] Fraud alert placement guidance provided to individuals
+- [ ] Dedicated FAQ page published with incident details and self-help guidance
+
+### 4.5 Recovery Validation
+
+Confirm the following before declaring the personal data breach workstream resolved:
+
+- [ ] All applicable regulatory notifications submitted within required timeframes
+- [ ] Individual notifications sent to all identifiable affected individuals
+- [ ] Credit monitoring or identity protection services activated (if applicable)
+- [ ] Dedicated support channel operational and staffed
+- [ ] Technical root cause addressed (confirmed with technical IR playbook lead)
+- [ ] No further unauthorized access to personal data detected
+- [ ] AWS Security Incident Response case updated with regulatory submission details (if applicable)
+- [ ] All evidence preserved under legal hold with documented chain of custody
+- [ ] Privacy Officer confirms notification obligations are satisfied (or follow-up timeline documented)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Complete regulatory follow-up, track individual notifications, update privacy controls, and improve data protection posture.
+
+Post-incident activities for personal data breaches extend well beyond the typical technical incident. Regulatory follow-up can continue for months (GDPR final reports, HIPAA annual reporting, enforcement proceedings), and individual notification tracking may require dedicated resources. The key difference from technical post-incident work is that *regulators will evaluate your response quality* — documentation produced here may be reviewed under enforcement action.
+
+### 5.1 Timeline Reconstruction
+
+Document the full incident timeline including both technical and regulatory workstreams. Complete within 24–48 hours while memory is fresh. This timeline will be referenced by regulators during any enforcement proceedings and should be treated as a formal record.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| YYYY-MM-DD HH:MM | Initial unauthorized access to personal data | CloudTrail data events | Threat actor |
+| YYYY-MM-DD HH:MM | Detection (Macie/GuardDuty/other) | Finding ID | AWS service |
+| YYYY-MM-DD HH:MM | IR team notified | On-call alert | IR Lead |
+| YYYY-MM-DD HH:MM | **Personal data involvement confirmed (CLOCK STARTS)** | Macie finding / manual review | IR Lead |
+| YYYY-MM-DD HH:MM | Privacy Officer notified | Internal escalation | IR Lead |
+| YYYY-MM-DD HH:MM | Technical containment applied | Technical playbook | IR Lead |
+| YYYY-MM-DD HH:MM | Legal hold initiated | Legal authorization | Legal Counsel |
+| YYYY-MM-DD HH:MM | Scope determination completed | Investigation findings | IR Lead + Privacy Officer |
+| YYYY-MM-DD HH:MM | Notification decision made | Regulatory assessment | Privacy Officer + Legal |
+| YYYY-MM-DD HH:MM | Regulator notification submitted | Submission confirmation | Privacy Officer |
+| YYYY-MM-DD HH:MM | Individual notifications sent | Delivery confirmation | Communications Lead |
+| YYYY-MM-DD HH:MM | Incident resolved | Recovery validation | IR Lead |
+
+**Key metrics to capture:**
+
+| Metric | Value | Why It Matters |
+|---|---|---|
+| Time to Detect (TTD) | *HH:MM from initial access to detection* | Indicates whether monitoring (Macie, GuardDuty) is tuned for personal data stores |
+| Time to Awareness (TTA) | *HH:MM from detection to personal data involvement confirmed* | Measures gap between generic alert and privacy-specific escalation |
+| Time to Notify Privacy Officer | *HH:MM from awareness to Privacy Officer notification* | Must be ≤1 hour. Directly consumes notification window. |
+| Time to Contain (TTC) | *HH:MM from awareness to access stopped* | Ongoing access increases both breach scope and regulatory exposure |
+| Time to Regulator Notification | *HH:MM from awareness to regulatory submission* | Must be ≤72 hours for GDPR. Late notification is itself a violation. |
+| Time to Individual Notification | *HH:MM from awareness to individual notifications sent* | Delayed individual notification increases harm to data subjects |
+| GDPR 72-hour compliance | *Yes/No — was regulator notified within 72 hours?* | Binary pass/fail metric for the most common regulatory deadline |
+| Total Incident Duration | *HH:MM from initial access to recovery validated* | Measures overall response effectiveness across both workstreams |
+| Individuals Affected | *Count (confirmed)* | Primary metric for regulatory severity assessment and media exposure risk |
+| Data Categories Involved | *List* | Determines which notification obligations apply and what protections to offer |
+| Jurisdictions Notified | *List* | Audit trail for regulatory compliance across all applicable jurisdictions |
+
+### 5.2 Regulatory Follow-Up
+
+> `[Privacy Officer]` owns ongoing regulatory engagement. `[Legal Counsel]` advises.
+
+Many regulations require follow-up after the initial notification:
+
+- [ ] **GDPR:** Final report submitted to DPA with complete investigation findings
+- [ ] **NIS2:** Final report submitted within 1 month of incident notification
+- [ ] **DORA:** Final report submitted within 1 month of initial notification
+- [ ] **HIPAA:** Annual report to HHS if breach affected >500 individuals
+- [ ] **Regulator questions:** All additional information requests from regulators answered within requested timeframes
+- [ ] **Enforcement actions:** Monitor for and respond to any regulatory enforcement proceedings
+- [ ] **Documentation:** Complete incident file maintained for minimum regulatory retention period (typically 5+ years)
+
+### 5.3 Individual Notification Tracking
+
+- [ ] Delivery confirmation received for all individual notifications
+- [ ] Undeliverable notifications re-sent via alternative method (postal if email bounced)
+- [ ] Support channel inquiry volume tracked and adequately staffed
+- [ ] Credit monitoring / identity protection enrollment rates tracked
+- [ ] Individual complaints or escalations documented and addressed
+- [ ] Public notice published (if individual notification not feasible for all affected persons)
+
+### 5.4 Post-Incident Review
+
+Conduct a blameless post-incident review within **5 business days** for P1/P2, **15 business days** for P3/P4. For personal data breaches, include the Privacy Officer and Legal Counsel in the review — their perspective on notification effectiveness and regulatory interaction is as important as the technical root cause analysis.
+
+Discussion questions (in addition to standard technical review):
+
+1. Was personal data involvement identified quickly enough? Could classification or tagging have accelerated this?
+2. Was the Privacy Officer notified within the 1-hour internal target?
+3. Were notification obligations assessed within 24 hours of awareness?
+4. Were regulatory notifications submitted within required timeframes? If not, why?
+5. Was the data inventory (ROPA) accurate and helpful during scope determination?
+6. Were individual notifications clear, complete, and delivered effectively?
+7. Did the organization have adequate data classification to quickly identify what was exposed?
+8. Were there gaps in S3 data event logging that hindered scope determination?
+9. Was Macie coverage sufficient to identify all personal data in the affected data stores?
+10. Were the preparation steps in Part 1 adequate? Were there tools, access, or processes we needed during the incident that weren't pre-provisioned?
+11. What single change would most reduce the likelihood or impact of a similar breach?
+
+### 5.5 Privacy & Data Protection Improvements
+
+Based on lessons learned, implement improvements:
+
+- [ ] **DPIA update:** Update the Data Protection Impact Assessment for the affected processing activity
+- [ ] **ROPA update:** Ensure Record of Processing Activities accurately reflects current data flows
+- [ ] **Data minimization:** Review whether all personal data in the affected store was necessary for the stated purpose
+- [ ] **Retention review:** Implement or enforce data retention policies to reduce volume of personal data at risk
+- [ ] **Macie coverage:** Expand Macie automated discovery to cover any gaps identified during the incident
+- [ ] **Access controls:** Implement least-privilege access to personal data stores (review IAM policies, bucket policies, VPC endpoints)
+- [ ] **Encryption:** Ensure all personal data is encrypted at rest with customer-managed keys (CMK) where appropriate
+- [ ] **Monitoring:** Enhance monitoring on personal data stores (CloudTrail data events, S3 access logging, GuardDuty S3 protection)
+- [ ] **Privacy by design:** Incorporate findings into development practices (data classification at creation, automated tagging, access logging by default)
+- [ ] **Training:** Update privacy and security awareness training based on incident root cause
+
+### 5.6 Detection Gap Analysis
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., Macie not enabled on affected bucket)* | *(Bucket created after Macie onboarding)* | *(Automate Macie coverage for new buckets via Config rule)* | | |
+| *(e.g., No CloudTrail data events on PII bucket)* | *(Data events not enabled for this bucket)* | *(Enable data events on all buckets tagged DataClassification:PII)* | | |
+| *(e.g., Cross-account access not alerted)* | *(No alarm on cross-account S3 access)* | *(Create CloudWatch alarm for cross-account GetObject on PII buckets)* | | |
+
+### 5.7 Playbook Update Checklist
+
+- [ ] Were triage questions sufficient to quickly identify personal data involvement?
+- [ ] Was the notification obligation assessment table complete for all applicable jurisdictions?
+- [ ] Were notification templates adequate or did they require significant modification?
+- [ ] Were evidence preservation steps sufficient for regulatory requirements?
+- [ ] Were any new regulations or jurisdictions identified that should be added?
+- [ ] Were Athena queries effective for scope determination?
+- [ ] Were communication templates clear and approved quickly by Legal?
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+---
+
+## Appendix A — Investigation Resources
+
+The full set of Athena queries and CLI commands for personal data breach investigation are maintained in a companion file for easier use in Athena consoles and scripts:
+
+📄 **[`resources/athena-queries-personal-data-breach.sql`](resources/athena-queries-personal-data-breach.sql)**
+
+This file contains:
+
+| Section | Queries | Purpose |
+|---|---|---|
+| **Evidence Collection** | 1.1–1.5 | Broad evidence capture for regulatory preservation — all access events, cross-account detection, individual count estimation, bulk download patterns, Macie correlation |
+| **Scope Determination** | 2.1–2.4 | Help the Privacy Officer determine breach scope — all access by suspect principal, data volume quantification, exfiltration indicators, configuration change detection |
+| **Finding Exports** | 3 (CLI) | GuardDuty and Macie CLI commands for exporting findings as regulatory evidence |
+
+> 📌 **Usage:** Replace placeholder values (bucket names, account IDs, role ARNs, time windows) with your actual values before running. The queries in Section 2.4 of the main playbook body are the most critical for the Privacy Officer's notification assessment and are kept inline for immediate reference.
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal Counsel]` and `[Privacy Officer]` own this section during an active incident.
+
+See [Regulatory Context](../REGULATORY_CONTEXT.md) for the full notification obligation matrix by regulation and incident type.
+
+### Notification Timeline Summary
+
+| Regulation | Clock Starts At | Initial Notification Deadline | Follow-Up Required |
+|---|---|---|---|
+| **GDPR Art. 33** | Awareness of breach | 72 hours to supervisory authority | Yes — final report when investigation complete |
+| **GDPR Art. 34** | Determination of high risk | Without undue delay to individuals | No fixed follow-up (but must be complete) |
+| **UK GDPR** | Awareness of breach | 72 hours to ICO | Yes — update if new information |
+| **PIPEDA** | Determination of RROSH | As soon as feasible to OPC + individuals | Records must be kept for 24 months |
+| **CCPA/CPRA** | Discovery of breach | Most expedient time possible (no fixed hours) | No fixed follow-up |
+| **HIPAA** | Discovery of breach | 60 days to HHS; without unreasonable delay to individuals | Annual report for breaches >500 |
+| **PCI-DSS** | Confirmation of compromise | Immediately to payment brands | Forensic investigation report required |
+| **Australian NDB** | Completion of assessment (30-day window) | As soon as practicable after assessment | Statement must remain on website for 12 months |
+| **NIS2** | Awareness of significant incident | 24 hours (early warning); 72 hours (notification); 1 month (final) | Final report within 1 month |
+| **DORA** | Classification as major incident | 4 hours (initial); 72 hours (intermediate); 1 month (final) | Final report within 1 month |
+| **SEC** | Materiality determination | 4 business days (Form 8-K) | Annual report (10-K) disclosure |
+
+### Key Principles for Notification Decisions
+
+1. **When in doubt, notify.** It is better to submit an incomplete initial notification and update later than to miss a deadline. Most regulations explicitly allow for phased reporting.
+
+2. **The clock starts at awareness, not confirmation.** For GDPR, "awareness" means a reasonable degree of certainty that a breach has occurred. You do not need to complete your investigation before notifying.
+
+3. **Containment does not eliminate notification obligations.** Even if you contained the breach within minutes, if personal data was accessed by an unauthorized party, notification obligations likely apply.
+
+4. **Encryption matters.** If data was encrypted with a strong algorithm AND the encryption key was not compromised, some regulations (notably HIPAA "safe harbor" and some GDPR interpretations) may not require notification. Document this analysis carefully.
+
+5. **Document the decision either way.** Whether you decide to notify or not, document the rationale. Regulators may later ask why you did or did not notify.
+
+### AWS Shared Responsibility for Breach Notification
+
+- **AWS responsibility:** Notify customers if AWS infrastructure is compromised (per AWS Customer Agreement and Shared Responsibility Model)
+- **Customer responsibility:** Notify regulators and individuals if customer data is breached due to customer configuration, access management, or application vulnerabilities
+- **AWS support:** AWS Security Incident Response service can assist with evidence gathering and documentation but does not provide legal advice on notification obligations
+
+---
+
+## Appendix C — Communication Templates
+
+> ⚠️ **These are starting templates only.** All notifications must be reviewed and approved by `[Legal Counsel]` before submission. Adapt language to your organization's tone, the specific incident facts, and jurisdictional requirements.
+
+### C.1 Regulator Notification Template (GDPR Art. 33)
+
+```
+PERSONAL DATA BREACH NOTIFICATION
+Submitted pursuant to Article 33 of the General Data Protection Regulation
+
+1. NATURE OF THE BREACH
+   - Type of breach: [Confidentiality / Integrity / Availability]
+   - Description: [Brief factual description of what occurred]
+   - Date/time breach occurred: [If known]
+   - Date/time breach discovered: [Timestamp]
+   - Categories of personal data: [e.g., names, email addresses, dates of birth,
+     government identification numbers]
+   - Approximate number of data subjects: [Number or range]
+   - Approximate number of records: [Number or range]
+
+2. DATA PROTECTION OFFICER CONTACT
+   - Name: [DPO name]
+   - Email: [DPO email]
+   - Phone: [DPO phone]
+
+3. LIKELY CONSEQUENCES
+   - [Description of potential impact on individuals — e.g., risk of identity theft,
+     financial fraud, reputational damage]
+
+4. MEASURES TAKEN OR PROPOSED
+   - Containment: [Actions taken to stop the breach]
+   - Mitigation: [Actions to reduce harm to individuals — e.g., credit monitoring,
+     password resets, enhanced monitoring]
+   - Prevention: [Actions to prevent recurrence]
+
+5. INDIVIDUAL NOTIFICATION
+   - Have individuals been notified? [Yes / No / Planned]
+   - If no, justification: [e.g., investigation ongoing, disproportionate effort,
+     data rendered unintelligible]
+
+6. ADDITIONAL INFORMATION
+   - [Any other relevant details]
+   - [Note: This is an initial notification. A supplementary report will follow
+     when the investigation is complete.]
+```
+
+### C.2 Individual Notification Template
+
+```
+Subject: Important Notice About Your Personal Data
+
+Dear [Name / "Valued Customer"],
+
+We are writing to inform you of a security incident that may have affected
+your personal data. We take the protection of your information seriously and
+want to provide you with the details of what happened, what we are doing
+about it, and what you can do to protect yourself.
+
+WHAT HAPPENED
+[Clear, factual description in plain language. Avoid technical jargon.
+Include approximate dates.]
+
+WHAT INFORMATION WAS INVOLVED
+The following categories of your personal data may have been affected:
+- [List specific data types — e.g., "your name, email address, and date of birth"]
+
+WHAT WE ARE DOING
+- [Containment action taken]
+- [Investigation status]
+- [Remediation steps]
+- [Offer of credit monitoring / identity protection if applicable]
+
+WHAT YOU CAN DO
+- [Specific, actionable steps — e.g., "Change your password at [URL]"]
+- [Monitor your accounts for unusual activity]
+- [Enroll in the complimentary credit monitoring service we are providing:
+  [enrollment URL/instructions]]
+- [Contact your bank if you notice unauthorized transactions]
+
+FOR MORE INFORMATION
+If you have questions or concerns, please contact our dedicated support team:
+- Email: [dedicated email]
+- Phone: [dedicated phone line]
+- FAQ: [URL to incident FAQ page]
+
+We sincerely apologize for this incident and any concern it may cause you.
+We are committed to protecting your information and are taking steps to
+prevent this from happening again.
+
+Sincerely,
+[Organization name]
+[Date]
+```
+
+### C.3 Internal Stakeholder Briefing Template
+
+```
+PERSONAL DATA BREACH — INTERNAL BRIEFING
+Classification: CONFIDENTIAL — DO NOT DISTRIBUTE EXTERNALLY
+
+Incident ID: [ID]
+Briefing Date: [Date]
+Prepared by: [Role]
+
+SUMMARY
+- Incident type: Personal data breach
+- Status: [Active / Contained / Resolved]
+- Severity: [P1/P2/P3/P4]
+- Individuals affected: [Count]
+- Data types: [Categories]
+- Jurisdictions: [List]
+
+NOTIFICATION STATUS
+- Regulator notifications: [Submitted / Pending / Not required]
+- Individual notifications: [Sent / Pending / Not required]
+- Deadlines: [Next deadline and countdown]
+
+ACTIONS REQUIRED
+- [Role]: [Action needed] by [deadline]
+- [Role]: [Action needed] by [deadline]
+
+NEXT UPDATE: [Date/time]
+```
+
+---
+
+## Appendix D — Data Classification Quick Reference
+
+### Amazon Macie Managed Data Identifiers (Key Categories)
+
+| Category | Examples | Regulatory Relevance |
+|---|---|---|
+| **Financial** | Credit card numbers (PAN), bank account numbers, SWIFT codes | PCI-DSS, CCPA, GDPR |
+| **Personal Identification** | SSN (US), SIN (Canada), TFN (Australia), NI number (UK), passport numbers | GDPR, PIPEDA, NDB, CCPA |
+| **Health** | Medical record numbers, health insurance IDs, prescription information | HIPAA, GDPR Art. 9 |
+| **Contact** | Email addresses, phone numbers, physical addresses | GDPR, CCPA, PIPEDA |
+| **Credentials** | AWS access keys, private keys, API tokens | All (if used to access personal data) |
+| **Demographic** | Dates of birth, gender, ethnicity, religious affiliation | GDPR Art. 9 (special categories) |
+
+### Data Classification Tags (Recommended)
+
+Apply these tags to S3 buckets, DynamoDB tables, RDS instances, and other data stores:
+
+| Tag Key | Tag Values | Purpose |
+|---|---|---|
+| `DataClassification` | `PII`, `PHI`, `PCI`, `Financial`, `Biometric`, `Public`, `Internal`, `Confidential` | Primary classification |
+| `DataSubjects` | `Customers`, `Employees`, `Partners`, `Patients`, `Children` | Identifies whose data |
+| `DataJurisdictions` | `EU`, `UK`, `CA`, `US-CA`, `AU`, `Global` | Determines applicable regulations |
+| `RetentionPolicy` | `30d`, `1y`, `3y`, `7y`, `Indefinite` | Data retention period |
+| `DPIARequired` | `Yes`, `No`, `Completed` | DPIA status |
+
+---
+
+## Appendix E — Reference Links
+
+### AWS Services & Documentation
+
+- [Amazon Macie User Guide](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)
+- [Amazon Macie Finding Types](https://docs.aws.amazon.com/macie/latest/user/findings-types.html)
+- [Amazon Macie Managed Data Identifiers](https://docs.aws.amazon.com/macie/latest/user/managed-data-identifiers.html)
+- [Amazon GuardDuty S3 Protection](https://docs.aws.amazon.com/guardduty/latest/ug/s3-protection.html)
+- [AWS CloudTrail Data Events](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html)
+- [AWS Security Incident Response Service](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Artifact](https://aws.amazon.com/artifact/)
+- [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+
+### Frameworks & Standards
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [NIST CSF 2.0](https://www.nist.gov/cyberframework)
+- [AWS Well-Architected Framework — Security Pillar: Incident Response](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/incident-response.html)
+- [AWS Well-Architected Framework — Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [AWS CIRT Workshop Materials (GitHub)](https://github.com/aws-samples/aws-incident-response-playbooks-workshop/)
+
+### Regulatory References
+
+- [GDPR Full Text (Art. 33 & 34)](https://gdpr-info.eu/art-33-gdpr/)
+- [UK ICO Breach Reporting](https://ico.org.uk/for-organizations/report-a-breach/)
+- [CCPA/CPRA Text](https://oag.ca.gov/privacy/ccpa)
+- [HIPAA Breach Notification Rule](https://www.hhs.gov/hipaa/for-professionals/breach-notification/index.html)
+- [PCI-DSS v4.0 Requirement 12.10](https://www.pcisecuritystandards.org/)
+- [PIPEDA Breach Reporting (OPC)](https://www.priv.gc.ca/en/privacy-topics/business-privacy/safeguards-and-breaches/privacy-breaches/respond-to-a-privacy-breach-at-your-business/)
+- [Australian NDB Scheme (OAIC)](https://www.oaic.gov.au/privacy/notifiable-data-breaches)
+- [NIS2 Directive](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive)
+- [DORA Regulation](https://www.digital-operational-resilience-act.com/)
+- [SEC Cybersecurity Disclosure Rules](https://www.sec.gov/rules/final/2023/33-11216.pdf)
+
+### Privacy & Data Protection
+
+- [EDPB Guidelines on Personal Data Breach Notification](https://edpb.europa.eu/our-work-tools/our-documents/guidelines/guidelines-92022-personal-data-breach-notification-under_en)
+- [ICO Personal Data Breach Assessment Guidance](https://ico.org.uk/for-organizations/report-a-breach/personal-data-breach-assessment/)
+- [OAIC Data Breach Preparation and Response Guide](https://www.oaic.gov.au/privacy/guidance-and-advice/data-breach-preparation-and-response)
+- [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/)
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | 2025-03-15 | IR Team | Initial draft — basic notification workflow |
+| 2.0 | 2026-05-28 | IR Team | Complete rewrite: NIST SP 800-61r3 alignment, expanded regulatory coverage (NIS2, DORA, SEC), Macie integration, Athena queries, communication templates, DPIA/ROPA references, Game Day scenario |
+| 2.1 | 2026-06-18 | IR Team | Modernization pass: Well-Architected references (SEC10-BP01/04/05/06), context paragraphs for all preparation sections, expanded escalation path to numbered steps, metrics with "Why It Matters" rationale, Athena queries moved to resources file, Section 2.7 expanded to P1–P3, Section 3.3 reframed as containment documentation, preparation adequacy review question, spelling standardization (American English), workshop resources added |

--- a/playbooks/IRP-Ransomware.md
+++ b/playbooks/IRP-Ransomware.md
@@ -1,132 +1,1097 @@
-# Incident Response Playbook Template
+# IRP-Ransomware: Ransomware in AWS Environments
 
-### Incident Type
-Ransomware
+> **Playbook Version:** 2.1
+> **Last Reviewed:** 2026-06-18
+> **Status:** `Active`
+> **NIST Framework:** SP 800-61r3 (CSF 2.0 Community Profile)
+> **Related Playbooks:** [IRP-CredCompromise](IRP-CredCompromise.md) | [IRP-EC2Compromise](IRP-EC2Compromise.md) (Coming Soon) | [IRP-DataAccess](IRP-DataAccess.md) | [IRP-S3DataExfiltration](IRP-S3DataExfiltration.md) (Coming Soon)
 
-### Introduction
-
-
-This playbook is provided as a template to customers using AWS products and who are building their incident response capability.  You should customize this template to suit your particular needs, risks, available tools and work processes.
-
-Security and Compliance is a shared responsibility between you and AWS. AWS is responsible for “Security of the Cloud”, while you are responsible for “Security in the Cloud”. For more information on the shared responsibility model, [please review our documentation](https://aws.amazon.com/compliance/shared-responsibility-model/).
-
-You are responsible for making your own independent assessment of the information in this document. This document: (a) is for informational purposes only, (b) references current AWS product offerings and practices, which are subject to change without notice, and (c) does not create any commitments or assurances from AWS and its affiliates, suppliers or licensors. This document is provided “as is” without warranties, representations, or conditions of any kind, whether express or implied. The responsibilities and liabilities of AWS to its customers are controlled by AWS agreements, and this document is not part of, nor does it modify, any agreement between AWS and its customers.
-
-## Summary
-
-### This Playbook
-
-This playbook outlines response steps for handling ransomware incidents.  These steps are based on the [NIST Computer Security Incident Handling Guide](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) (Special Publication 800-61 Revision 2) that can be used to:
-
-•	Gather evidence
-•	Contain and then eradicate the incident
-•	recover from the incident
-•	Conduct post-incident activities, including post-mortem and feedback processes
-
-Interested readers may also refer to the [AWS Security Incident Response Guide]( https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/welcome.html) which contains additional resources.  
-
-Once you have customized this playbook to meet your needs, it is important that you test the playbook (e.g., Game Days) and any automation (functional tests), update as necessary to achieve the desired results, and then publish to your knowledge management system and train all responders.
-
-Note that some of the incident response steps noted below may incur costs in your AWS account(s) for services used in either preparing for, or responding to incidents. Customizing this playbook and testing it will help you to determine if additional costs will be incurred. You can use [AWS Cost Explorer](https://aws.amazon.com/aws-cost-management/aws-cost-explorer/) and look at costs incurred over a particular time frame (such as when running Game Days) to establish what the possible impact might be.
-
-In reviewing this playbook, you will find steps that involve processes that you may not have in place today. Proactively preparing for incidents means you need the right resource configurations, tools and services in place that allow you to respond to an incident.
-
-The next section will provide a summary of this incident type, and then cover the five steps (parts 1 - 5) for handling ransomware incidents.
-
-## This Incident Type
-
-Ransomware is malicious code designed by threat actors to gain unauthorized access to systems and data and to encrypt the data to block access by legitimate users. Once ransomware has locked users out of their systems and/or encrypted their sensitive data, the actors demand a ransom. In theory, if the ransom is paid, access to the data is returned (such as by providing an encryption key), but equally, some studies have suggested the victim will subsequently be attacked again. Alternatively, if not paid, the organization risks permanent data loss and/or data leaks to the public, competitors or other malicious actors.
-
-There are usually limited options to mitigate a successful ransomware attack once it has occurred.  The best mitigation is to reduce the chance that it can happen in the first place. The AWS Well-Architected security pillar provides a framework to implement AWS best practice, including operating workloads security (security foundations section), protecting compute resources (infrastructure protection section) and others. The security pillar encompasses the ability to protect data, systems, and assets to take advantage of cloud technologies to improve your security. This playbook covers steps that can be used to deal with ransomware.
-## Incident Response Process
 ---
-### Part 1: Acquire, Preserve, Document Evidence
 
-1.  You become aware that a possible ransomware incident has occurred. This information could come via different means, depending on your configurations in your AWS environment:
-1.	A colleague reports that an EC2 instance cannot be accessed by SSH or similar, however the instance appears to be correctly configured with appropriate network access in place, and there are no related service issues reported by AWS in the Service Health Dashboard
-2.	Your ticketing system creates a ticket for unusual metrics or logs from the EC2 instance
-3.	The instance is reporting network reachability issues in the AWS console, or via Amazon CloudWatch alarms
-4.	Message from threat actor through alternate communication channel such as email about the ransom demand
-5.	Findings through services like AWS Security Hub or Amazon GuardDuty.
-6.	Other alarms or metrics you have configured in your monitoring systems, either internal or external to AWS
+> ⚠️ **Disclaimer:** This playbook is provided as a template only. It should be customized to suit your organization's specific needs, risks, available tools, and work processes. This guide is not official AWS documentation and is provided as-is. Security and Compliance is a shared responsibility between you and AWS. You are responsible for making your own independent assessment of the information in this document.
 
-2. Once you confirm that an event is a security incident, it is important to determine the scope of impact (quantity of resources as well as sensitivity of data).
-1.	Determine if there are any known events that could be causing service disruption, or impacting instance metrics (e.g., network CloudWatch metrics increasing due to a sales event, or similar)
-2.	Use Amazon Detective to investigate any ongoing activity using the time based analysis or a specific period when the incident was identified to identify any deviations from a “normal” operating baseline.
-3.	Obtain the application’s documented baseline and locate the metrics for standard application performance from the CloudWatch or other application performances monitoring tool used in the organization to compare baseline behavior to anomalous behavior as a result of the incident.
-4.	Determine the classification level of any data that resides in the EC2 instance, S3 bucket, Amazon Workspaces instance, etc.
-5.	Confirm a ticket/case has been raised for the incident. If not, manually raise one.
-6.	If you received an abuse notification from AWS, determine if any cases are already open for the resource that can be correlated to the abuse notification. This may provide indications relating to prior unauthorized activity.
-7.	If there is a ticket/case already opened, determine what internal alarms/metrics are currently indicating an issue (if automated, what caused the ticket to be created?) If the ticket/case creation was not initiated automatically by an alarm or metric, document the alert/notification that led to identification of the issue if there was one (for example, a ransom demand popping up on the screen, or metrics that indicate the device is no longer on the network). If the incident was identified by an indicator that does not conclusively identify a ransomware incident as the cause, then verify the service disruption is not due to any planned (or other) event and document the actual vector.
-8.	Identifying the ransomware strain is key to recovery. For example, if objects in S3 buckets are inaccessible with an error of not having encryption key access, the first step would be to review the S3 object properties section to understand the encryption key applied. A similar approach can be leveraged with the Amazon Elastic Block Store (EBS)volumes in situations involving crypto ransomware.
-9.	Using your preferred monitoring tool, access AWS CloudTrail and search for any API actions which indicates any credential compromise attack vector and refer to the playbook, “Credential Leakage/Compromise”.
-10.	Determine when the infection occurred using log search. CloudWatch can help you to review logs such as application logs, operating system logs, database logs, etc.
+---
 
-11.	Determine the business impact:                                                                                                                                          
-a.	Identify application(s) impacted; this may be achieved via Resource Tags, or by an internal Configuration Management Database (CMDB)
-b.	Identify business owner and workload classification (example: mission critical, high risk, etc.)
-12.	Determine and begin to document end-user impact/experience of the issue. This should be documented in the ticket/case related to the incident. If there are impacted users, determine from them the steps that led to the incident. This will assist you to establish the attack vector used to execute the ransomware. Mitigations against this vector should be placed in later steps of this process.
-13.	Internal Communications:
-a.	Identify stakeholder roles from your organization’s incident response plan, the application entry in the Configuration Management Database CMDB (if one exists), or via the application’s risk register
-b.	Open an Incident Response bridge to have a regular communication channel about the incident.
-c.	Notify identified stakeholders including (if required) legal personnel, technical teams and developers and add them to the ticket and the war room, so they are updated as the ticket is updated
-14.	External Communications:
-i.	Ensure your organization’s legal counsel is informed and is included in status updates to internal stakeholders and especially in regards to external communications.
-ii.	For colleagues in the organization that are responsible for providing public/external communication statements, ensure these internal stakeholders are added to the ticket so they receive regular status updates regarding the incident and can complete their own requirements for communications within and external to the business.
-iii.	If there are regulations in your jurisdiction requiring reporting of such incidents, ensure the people in your organization responsible for notifying local or federal law enforcement agencies are also notified of the event. Consult your legal advisor and/or law enforcement for guidance on collecting and preserving the evidence and the chain of custody.
-iv.	There may not be regulations, but either open databases, government agencies or NGOs may track this type of activity. Your reporting may assist others
+## Overview
 
-### Part 2: Contain the Incident
+Ransomware in AWS environments differs significantly from traditional on-premises ransomware. Rather than encrypting local filesystems via malware execution, cloud-native ransomware typically leverages compromised credentials to perform destructive actions through AWS APIs — encrypting EBS volumes with threat actor-controlled KMS keys, deleting S3 object versions and replacing them with ransom notes, destroying RDS/Aurora snapshots, or disabling backup protections. The threat actor's goal is to deny the organization access to its own data and demand payment for restoration. Detection relies heavily on CloudTrail analysis, GuardDuty findings for unusual KMS and deletion activity, and monitoring for bulk destructive API patterns. Recovery depends on the organization's backup posture — particularly immutable backups via AWS Backup Vault Lock, S3 Object Lock, and EBS Snapshots Lock.
 
-Early detection of anomalous user behavior or network activity is key to reducing the impact of ransomware incidents. The below steps can be taken to help to contain the incident. If applicable, work with the legal and compliance team of your organization on any required response and continue the incident response process outlined here.
-1.	If possible, determine the type of ransomware used in the incident:
-a.	Crypto Ransomware - Objects/files will be encrypted
-b.	Locker ransomware - Locks out access to the device
-c.	A different type, or previously not observed type
-2.	For identified AWS resources associated with your impacted workloads, isolate network or internet connectivity by modifying Security groups, S3 bucket Policies or relevant identity and access management policies as applicable to minimize opportunities for the infection to be spread, or for threat actors to have access to those resources. Keep in mind that sometimes modifying security groups may not have the intended impact, due to connection tracking.
-3.	Determine whether the EC2 instance actually needs to be recovered, or not. For example, if the impacted instance is part of an AWS Application Auto Scaling group, removing the instance from the group will trigger a scaling action. If the incident is linked to a vulnerable package on the host’s operating system, updating the AMI used in the Launch configuration and confirming the vulnerability has been patched (check the Mitre CVE database) will also be required.
-4.	Check your CloudTrail log for unauthorized activity such as creation of unauthorized IAM users, policies, roles or temporary security credentials. Delete any unauthorized IAM users, roles, and policies, and revoke any temporary credentials.
-5.	If you’re dealing with this incident as part of a broader security incident in the account, a drastic approach could be to use AWS Organizations Service Control Policies (SCPs) to restrict any API call to be made from that AWS account (assuming it is not the master account of the Organization). Please note this may impact other running workloads as SCPs applied at the account level will be enforced on all the IAM entities associated in it. This may prevent malicious actors from inflicting further damage on the account’s resources and data.
-6.	If the attack vector was made possible by un-patched software, operating system updates, out-of-date malware/anti-virus tools, ensure that all EC2 instances are either updated to the latest version of operating system, all software packages and patches are up-to-date and virus signatures and definition files on all EC2 instances are up-to-date. This may be done by several methods:
-a.	Patch-in-place for mutable architectures
-b.	Re-deploy for immutable architectures
-7.	Depending on what occurred in Step 6 above, remove any remaining resources that are identified as being at risk of infection (that may have accessed the same vector that downloaded the ransomware, whether that be via email, visiting an infected website, or something else). If it is part of a larger fleet managed by Auto Scaling, containment efforts may be better focused on establishing the attack vector and then placing mitigations that will prevent other resources in the fleet from becoming infected via the same vector.
+### Out of Scope
 
+This playbook does **not** cover:
 
-### Part 3: Eradicate the Incident
-1.	It is important to understand if the impact from the incident is contained to a subset of the environment. If there is an ability to restore the ransomed data from backups/snapshots, you can refer to the recover from the incident section.  Note that there may still be value in exploring the incident under an isolated environment to run the root cause analysis and use controls to avoid situation in the future.
-2.	Investigate potential use of up-to-date antivirus or anti-malware software to clean the ransomware. Refer to this step with caution as it may alert the actor (see earlier steps to remove network access from the impacted EC2 instance). You can review the locked/encrypted objects in an isolated forensic environment.
-3.	Review any GuardDuty findings if there are any high or medium severity alerts that can help to reduce the additional effort required to search application level logs. GuardDuty findings provide recommendations on how to remediate the finding.
-4.	Remove any malware that was identified during the forensic analysis and identify Indicators of Compromise.
-5.	If the ransomware strain has been identified, determine if any 3rd party decryption tools are available, or if any other online resources may help
+- **Initial credential compromise** — If you are still in the process of identifying and containing the compromised credential that enabled the ransomware activity, start with [IRP-CredCompromise](IRP-CredCompromise.md) and return here once containment of the credential is complete.
+- **EC2 instance-level malware (file-encrypting ransomware running inside an instance)** — If ransomware is executing as a process within an EC2 instance (traditional file encryption), see [IRP-EC2Compromise](IRP-EC2Compromise.md) (Coming Soon) for instance isolation and forensics. Return here if the threat actor is also performing API-level destructive actions.
+- **Data exfiltration without encryption/destruction** — If the threat actor is copying data out without encrypting or destroying it (double-extortion exfiltration component), see [IRP-S3DataExfiltration](IRP-S3DataExfiltration.md) (Coming Soon) for the exfiltration response. This playbook focuses on the denial-of-access component.
+- **Extortion without technical action** — If you receive a ransom demand but no technical evidence of encryption or deletion, treat as a threat/social engineering event and engage Legal.
 
-### Part 4: Recover from the Incident
-1.	Identify the restore point for any restore operation performed from backup.
-2.	Review the backup strategy and see if you can recover all the objects and files. This will depend on the lifecycle policies applied on the resources.
-3.	Restore the data from your backup, or revert to an earlier snapshot of the EC2 instance’s volumes. Apply forensic methods to confirm that data is clean before restoring it. Ensure any spread vectors are identified & resolved.
-4.	Alternatively, if you have been successful in using any open source de-crypter tool to retrieve the data, remove that data from the instance and perform any required analysis to ensure the data is clean.  Then, recover the instance, terminate it or quarantine it and create a new one, and restore the data to a new instance.
-5.	If restoring from a backup and de-crypting the data is not an option, consider whether to start from entirely new environment is a possibility .
+### Applicable Finding Types
 
-### Part 5: Post-Incident Activity
-1.	Documenting and cycling lessons learned during simulations and live incidents back into “new normal” processes and procedures allows organizations to better understand how an incident occurred with their configurations and processes – such as where they were vulnerable, where automation may have failed, or where visibility was lacking – and the opportunity to strengthen their overall security posture.
-2.	If you identified the initial attack vector or point of entry, determine how best to mitigate the risk of a re-occurrence. For example, if the malware gained initial entry due to an un-patched public-facing EC2 instance, and assuming you applied the missing patch to all current instances, how can you improve your patching process to ensure that patches are tested and applied sooner and with more consistency and reliability?
-3.	If you’ve developed set technical steps to take for a given threat, assess opportunities to automate those actions upon detection to mitigate the threat as quickly as possible to minimize scope and severity of impact.
-4.	Ensure you collect lessons learned from all stakeholders and update your incident response plan, disaster recovery plans, and this playbook as necessary. And where appropriate, consider priorities and funding for new technical capabilities and personnel skills to fill any gaps.
+| Source | Finding / Event Type | Severity |
+|---|---|---|
+| Amazon GuardDuty | `Execution:EC2/MaliciousFile` | HIGH |
+| Amazon GuardDuty | `Execution:ECS/MaliciousFile` | HIGH |
+| Amazon GuardDuty | `Execution:EC2/SuspiciousFile` | MEDIUM |
+| Amazon GuardDuty | `Impact:EC2/BitcoinDomainRequest.Reputation` | HIGH |
+| Amazon GuardDuty | `CryptoCurrency:EC2/BitcoinTool.B!DNS` | HIGH |
+| Amazon GuardDuty | `UnauthorizedAccess:IAMUser/AnomalousBehavior` | MEDIUM |
+| Amazon GuardDuty | `Persistence:IAMUser/AnomalousBehavior` | MEDIUM |
+| Amazon GuardDuty | `Impact:S3/AnomalousBehavior.Delete` | HIGH |
+| Amazon GuardDuty | `Impact:S3/AnomalousBehavior.Write` | HIGH |
+| Amazon GuardDuty | `Exfiltration:S3/AnomalousBehavior` | HIGH |
+| AWS Security Hub | AWS Foundational Security Best Practices — S3 controls | MEDIUM |
+| AWS Security Hub | AWS Foundational Security Best Practices — Backup controls | MEDIUM |
+| CloudTrail | `eventName: CreateKey` (KMS — from unusual principal or region) | — |
+| CloudTrail | `eventName: Encrypt` / `ReEncrypt*` (KMS — bulk operations) | — |
+| CloudTrail | `eventName: DeleteSnapshot` / `DeregisterImage` (bulk) | — |
+| CloudTrail | `eventName: PutBucketVersioning` (Status: Suspended) | — |
+| CloudTrail | `eventName: DeleteObjects` / `DeleteObject` (bulk) | — |
+| CloudTrail | `eventName: DeleteDBSnapshot` / `DeleteDBClusterSnapshot` | — |
+| CloudTrail | `eventName: PutObject` (ransom note files — e.g., `RANSOM_NOTE.txt`) | — |
+| CloudTrail | `eventName: DisableKey` / `ScheduleKeyDeletion` (KMS) | — |
+| CloudTrail | `eventName: DeleteBackupVault` / `DeleteRecoveryPoint` | — |
+| Custom / Third-Party | SIEM correlation: bulk deletion patterns, unusual KMS usage spikes | HIGH |
+| Custom / Third-Party | Billing anomaly: unexpected KMS charges or cross-region data transfer | MEDIUM |
 
-## Appendix A
-### Preparation
+> 📌 GuardDuty finding types are updated regularly. See the [GuardDuty finding types reference](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html) for the current list.
 
-As with other incident response scenarios, mitigating ransomware threats requires a strong preventative strategy and preparation is very important. More so than others though, mitigation techniques rely on adequate preparation prior to a ransomware incident. Implementing best practices based on the AWS Well-Architected Framework will help you in your preparation. If key preventative measures are not already in place, these must be considered as part of any post-incident activity including any tools or techniques that failed during the incident response process itself, such as automation, integration with partner offerings, application and systems observability, etc. The below points cover some key preparation steps.
+### Severity Classification
 
-1.	Adopt foundational best practices:  Leverage AWS Cloud Adoption Framework (CAF) and AWS Well-Architected best practices to your organization's cybersecurity framework such as the NIST CyberSecurity Framework for AWS, a framework focused on security outcomes organized around five functions (Identify, Protect, Detect, Respond, Recover) and foundational activities that map to existing standards, accreditations and frameworks.
-2.	Training:  Cybersecurity awareness training for your employees. Social engineering is one of the common methods used to induce end users to download an infected file.
-3.	Deep dive on assets and configurations:  Identifying your IT assets is a vital component of governance and security. You must have visibility into all your data storage services and resources in order to evaluate their security posture and effectively configure them. Reduce potential attack surface, for instance, by analysing your public data footprint. If you use Amazon Simple Storage Service (S3), ensure that your S3 buckets use the correct policies and are not publicly accessible. Implement the idea of least privilege enterprise-wide. With S3 Versioning, existing versions of your data are immutable: actors cannot change existing objects, and any modification is going to result in a new version. Use MFA delete to require a second element of authentication for S3 data deletion. In addition, S3 includes a number of security controls to consider when developing and implementing your own security policies; for more information, please see [security best practices for Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security-best-practices.html).
-4.	Stay up-to-date with system patches:  Ransomware often relies on exploit kits to gain access to a system or network using known threats. Amazon Elastic Compute Cloud (Amazon EC2) resources can use AWS Systems Manager to automatically collect software inventory, apply OS patches, create system images, and configure Windows and Linux operating systems. These capabilities enable automated configuration and ongoing management of systems at scale, and help maintain software compliance for instances running in EC2.
-5.	Continuous monitoring:  
-a.	Use Amazon Inspector to assess your deployed EC2 instances for CVEs and deviation from best practice. Build a CI/CD pipeline to remediate security findings automatically & periodically. Amazon Inspector finds applications by querying the package manager or software installation system on the operating system where the agent is installed. This means that software that was installed through the package manager is assessed for vulnerabilities. You can also leverage AWS Security Competency Partner offerings to help inspect your application deployments for security risks and vulnerabilities, while providing priorities and advice to assist with remediation.
-b.	AWS developed a new open source Self-Service Security Assessment tool (with ransomware analysis modules) that provides customers with a point-in-time assessment to quickly gain valuable insights into the security posture of their AWS account. For continuous monitoring of your security posture, AWS recommends enabling AWS Security Hub’s Foundational Security Best Practices standard, which also provides automated security checks.
+| Priority | Criteria |
+|---|---|
+| **P1 — Critical** | Active encryption or deletion of production data confirmed; threat actor still has access; ransom demand received with evidence of data destruction; backup integrity uncertain |
+| **P2 — High** | Bulk destructive API calls detected (snapshots deleted, versioning disabled), threat actor access revoked but damage scope unclear; OR ransom demand received with no confirmed technical action yet |
+| **P3 — Medium** | Anomalous KMS or deletion activity detected, no confirmed data loss; OR single non-production account affected with confirmed good backups |
+| **P4 — Low** | Ransom demand received with no technical evidence of compromise; OR post-incident review of a contained ransomware event |
 
-6.	Data back-up:  Create secure backups of your data on a regular basis. AWS Backup is a fully managed backup service that makes it easy to centralize and automate the backup of data across AWS services.  If backups are not a requirement, ensure that there are regular snapshots or an up-to-date AMI that can be used either for recovery or replacement of the impacted EC2 instance. Amazon S3 and Amazon Glacier are durable, low-cost storage platforms. Both offer unlimited capacity and require no volume or media management as backup data sets grow. Backup and Recovery Approaches Using AWS.
-7.	Testing:  Implement, review and test disaster recovery scenarios for your organizational needs. This will help you determine the path for implementing recovery mechanisms and mitigate risks. Disaster recovery is about preparing for and recovering from an event that has a negative impact on your business goals. You can use CloudEndure Disaster Recovery to quickly recover your environment, minimizing data loss and downtime in the case of a ransomware incident.
-8.	Automation:  Where you identify fixed technical procedures that don’t deviate or require a human to make a decision, explore the opportunity to automate protections and response actions to mitigate the threat as quickly as possible to minimize scope and severity of impact.
-Communication channels:  Identify communication channels such as an Incident Response bridge that you will need to use during the incident to communicate with the internal and external stakeholders.
+---
+
+## Part 1 — Prepare
+
+> **CSF 2.0 Functions:** Govern · Identify · Protect
+> **Goal:** Ensure the right configurations, access, and processes are in place *before* this incident type occurs.
+
+### 1.1 Recommended AWS Service Configurations
+
+The following services each contribute to your ability to detect, investigate, and respond to ransomware. None are strictly required, but each addresses a specific gap — the more you have enabled, the faster you can detect destructive activity and the more complete your recovery options will be during an incident.
+
+- [ ] **Amazon GuardDuty** enabled in all regions with Malware Protection for EC2 and S3 enabled — provides continuous threat detection for malware execution, anomalous deletion patterns, and KMS abuse
+- [ ] **AWS CloudTrail** enabled with multi-region trail, management + data events for S3 and KMS — the primary audit log for all API activity; without S3 and KMS data events, ransomware investigation is severely limited
+- [ ] **CloudTrail Insights** enabled — detects unusual API call volume, critical for identifying bulk deletion patterns that indicate automated ransomware tooling
+- [ ] **AWS Config** enabled with rules for backup compliance (`backup-plan-min-frequency-and-min-retention-check`, `backup-recovery-point-encrypted`) — continuous validation that backup posture meets requirements
+- [ ] **AWS Backup** configured with Backup Vault Lock (compliance mode) on critical backup vaults — the single most important ransomware defense; compliance-mode locks cannot be removed, even by account administrators
+- [ ] **S3 Object Lock** enabled on buckets containing critical data (Governance or Compliance mode) — prevents deletion or overwriting of object versions
+- [ ] **S3 Versioning** enabled on all production buckets (cannot be disabled once Object Lock is set) — allows recovery of deleted or overwritten objects
+- [ ] **EBS Snapshots Lock** enabled on critical snapshots (lock in compliance mode for immutability) — prevents snapshot deletion during an attack
+- [ ] **KMS key policies** restrict `CreateKey`, `CreateGrant`, and `ScheduleKeyDeletion` to authorized principals only — limits threat actor ability to create encryption keys
+- [ ] **SCPs** in place to prevent disabling of versioning, deletion of backup vaults, or KMS key deletion in production OUs — organizational guardrails that even compromised admin credentials cannot override
+- [ ] **Amazon Detective** enabled for graph-based investigation of API activity chains — reduces time to scope the extent of destructive operations
+- [ ] **Security Hub** enabled with AWS Foundational Security Best Practices standard — aggregates backup, S3, and KMS findings into a single view
+- [ ] **AWS Elastic Disaster Recovery** configured for critical workloads (RPO/RTO validated) — provides fastest recovery path for full-instance restoration
+- [ ] **VPC Flow Logs** enabled for all production VPCs — supports investigation of lateral movement and C2 communication
+
+> 🤖 **Automation opportunity:** Deploy an EventBridge rule that triggers automatic EBS snapshot creation when GuardDuty generates a malware finding for an EC2 instance. This preserves the pre-encryption state. See [Appendix D](#appendix-d--automation-hooks) for implementation.
+
+> 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
+
+### 1.2 IAM & Access Prerequisites
+
+Effective incident response depends on having the right access available *before* an incident occurs. Provisioning break-glass access during an active ransomware event wastes critical minutes — minutes during which data is being encrypted or deleted. The following recommendations align with [SEC10-BP05 Pre-provision access](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_provision_access.html) from the AWS Well-Architected Framework.
+
+- [ ] **Break-glass IAM role** exists in each account with permissions to: attach deny policies, modify security groups, copy/create snapshots, manage KMS keys, and query CloudTrail — pre-tested and documented
+- [ ] **IR team members can assume the break-glass role** with MFA from a trusted (non-production) account — validate this works at least quarterly
+- [ ] **Pre-built IAM deny policies** ready to attach during containment (see [Part 3 — Contain](#part-3--contain)):
+  - `DenyAllKMSActions` — blocks `kms:Encrypt`, `kms:CreateKey`, `kms:CreateGrant`, `kms:ScheduleKeyDeletion`
+  - `DenyDestructiveS3Actions` — blocks `s3:DeleteObject*`, `s3:PutBucketVersioning`
+  - `DenySnapshotDeletion` — blocks `ec2:DeleteSnapshot`, `rds:DeleteDBSnapshot`, `rds:DeleteDBClusterSnapshot`
+- [ ] **Forensic account** available with cross-account snapshot copy permissions — isolated from production
+- [ ] **Access to AWS Security Incident Response console** confirmed (if subscribed) — verify case creation workflow before you need it
+- [ ] **AWS Backup restore permissions** tested and validated (restore to forensic account) — do not discover permission gaps during a P1
+- [ ] **SCP templates** prepared for emergency deployment to block destructive actions org-wide — pre-tested in a non-production OU
+
+### 1.3 Communication & Escalation
+
+Clear communication paths reduce confusion during high-pressure incidents. Ransomware events escalate quickly, involve multiple stakeholders (Legal, executives, potentially law enforcement), and may require time-sensitive decisions about ransom payment. Define who needs to be involved, at what severity threshold, and through which channel *before* you need them.
+
+> 📋 Do not include names in this playbook. Use roles only. Maintain a separate, access-controlled contact list (e.g., internal wiki, sealed envelope, or secure document) with current names, phone numbers, and escalation preferences.
+
+| Role | Responsibility | When to Engage |
+|---|---|---|
+| IR Lead | Overall incident coordination, status updates, recovery prioritization | All severity levels — first notified |
+| Account Owner | Business context, authorization for containment actions, recovery decisions | P1–P3, or when containment may disrupt services |
+| Backup Administrator | Validate backup integrity, execute restore operations | All severity levels — critical for recovery |
+| Legal / Compliance | Regulatory notification, ransom payment decision guidance, law enforcement liaison | P1–P2, or when ransom demand received at any severity |
+| Communications | Internal messaging, customer notification (if applicable) | P1–P2, or when customer-facing services are impacted |
+| Executive Sponsor | Authorize business-impacting decisions (e.g., ransom payment, extended downtime) | P1–P2, or when ransom payment is being considered |
+| AWS CIRT | Engage via AWS Support case or Security Incident Response service | P1–P2 (if available); P3 for backup integrity validation |
+| Law Enforcement | FBI IC3 / local CERT reporting (coordinate through Legal) | When ransom demand received, or when required by regulation |
+
+**Escalation path:**
+
+1. **Detection:** Automated alert (GuardDuty, Security Hub, SIEM) or human report triggers initial notification.
+2. **Triage (IR Lead, < 10 min):** IR Lead assesses severity using [Section 2.3](#23-severity-determination). Determines if the threat actor is still active and whether data destruction is confirmed.
+3. **Severity-based escalation:**
+   - **P1 (active destruction):** IR Lead begins containment immediately (standing authority — see [Section 3.1](#31-containment-decision)). Notifies Account Owner, Legal, and Executive Sponsor in parallel. Opens AWS Support case (severity: Critical) requesting CIRT assistance.
+   - **P2 (confirmed damage, contained):** IR Lead notifies Account Owner and Legal. Opens AWS Support case for CIRT assistance with scoping and recovery.
+   - **P3 (anomalous, unconfirmed):** IR Lead manages internally with Backup Administrator. Escalates to P2 if investigation confirms data loss.
+4. **Status updates:** IR Lead provides updates every 15 minutes (P1), every 1 hour (P2), or at key milestones (P3/P4).
+
+> ⚠️ **Ransom payment decisions** require Executive Sponsor and Legal involvement. IR Lead does not have authority to approve or deny payment. Consult your organization's Legal counsel and cyber insurance provider.
+
+> 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — recommends identifying and documenting internal and external resources and contact information ahead of time.
+
+### 1.4 Game Day Guidance
+
+Practicing incident response before a real incident occurs builds muscle memory, identifies gaps in backup coverage and tooling access, and validates that recovery procedures work under time pressure. Teams that exercise regularly contain ransomware incidents faster and make better recovery decisions.
+
+Recommended testing cadence: **Semi-annually** (this is a P1-capable scenario with complex recovery procedures).
+
+Suggested tabletop scenario:
+> *"A threat actor has compromised an IAM user's access key (obtained from a phishing campaign targeting developers). The key has PowerUserAccess in a production account. Over the past 2 hours, the threat actor has: (1) created a new KMS key in us-east-1, (2) begun re-encrypting EBS volumes attached to production EC2 instances with the threat actor-controlled key, (3) suspended versioning on three S3 buckets and is bulk-deleting objects while uploading RANSOM_NOTE.txt files, and (4) deleted 5 RDS automated snapshots. Your GuardDuty finding fired 15 minutes ago. The threat actor appears to still be active. You have AWS Backup Vault Lock enabled on your primary backup vault, but you're unsure if all critical resources are covered by backup plans."*
+
+Exercise should validate:
+- Speed of credential revocation and SCP deployment
+- Backup integrity verification process
+- Cross-account snapshot copy procedures
+- Communication flow to Legal and Executive Sponsor
+- Recovery prioritization decisions under pressure
+
+**Practice resources (no paid service or support plan required):**
+
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/) — free, hands-on workshops covering credential compromise, S3 ransomware, and more. Deployable in any AWS account.
+- [Incident Response Playbooks Workshop](https://catalog.workshops.aws/incident-response-playbooks) — step-by-step exercises aligned with these playbooks.
+- [AWS Security Workshops catalog](https://workshops.aws/categories/Security) — broader collection of security-focused hands-on labs.
+
+> 📖 **Reference:** [SEC10-BP04 Develop and test security incident response playbooks](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_playbooks.html) — recommends creating and regularly testing playbooks to verify response processes.
+
+---
+
+## Part 2 — Detect & Analyze
+
+> **CSF 2.0 Functions:** Detect · Respond (Analyze)
+> **Goal:** Confirm whether an incident has occurred, scope its impact, and gather evidence for containment and investigation.
+
+### 2.1 Initial Triage Questions
+
+Not every alert is confirmed ransomware. The purpose of triage is to quickly determine whether active data destruction is occurring (requiring immediate containment) or whether you have time to investigate before acting. Answer these questions to establish scope and urgency — each should take less than 2 minutes. For ransomware, speed of assessment directly correlates with data preserved.
+
+- [ ] What type of destructive activity is occurring? (EBS encryption, S3 deletion, snapshot destruction, backup deletion)
+- [ ] Is the threat actor still active? (Check for ongoing API calls from the compromised principal)
+- [ ] Which accounts and regions are affected? (Check CloudTrail across the organization)
+- [ ] Has a ransom demand been received? (Check for ransom note files in S3, emails, or other channels)
+- [ ] What is the compromised principal? (IAM user, role, federated session — route to IRP-CredCompromise for credential containment)
+- [ ] Are backups intact? (Check AWS Backup vault, S3 versioned objects, cross-region/cross-account copies)
+- [ ] Is AWS Backup Vault Lock enabled on relevant vaults? (If yes, recovery points are protected)
+- [ ] Are production workloads currently impacted? (Application health, customer impact)
+- [ ] Has the threat actor modified lifecycle or deletion policies? (Check KMS key policies for scheduled deletion, S3 lifecycle rules for accelerated expiration, RDS backup retention reduced to 0, AWS Backup vault deletion attempts — any of these could cause data loss mid-investigation or make recovery impossible)
+- [ ] Are there signs of data exfiltration in addition to encryption/deletion? (Double extortion)
+
+**If the threat actor is still active AND production data is being destroyed → P1 immediately. Proceed to containment in parallel with evidence collection.**
+
+### 2.2 Evidence Documentation
+
+> ⚠️ **For active ransomware (P1): Begin containment IMMEDIATELY while collecting evidence in parallel.** Unlike credential compromise where you collect before acting, active data destruction requires simultaneous containment and evidence collection.
+
+Whether the activity is confirmed malicious or still under investigation, document the current state. For ransomware scenarios, the primary evidence sources are CloudTrail (API-level destruction) and service-specific state (snapshot inventory, versioning status, key policies).
+
+| Evidence Type | How to Collect | Where to Store |
+|---|---|---|
+| CloudTrail events (KMS, EC2, S3, RDS, Backup) | Athena query (see resources file) | Forensic S3 bucket |
+| GuardDuty findings (malware, anomalous behavior) | `aws guardduty get-findings` | Forensic S3 bucket |
+| KMS key policies (threat actor-created keys) | `aws kms get-key-policy --key-id ...` | Forensic S3 bucket |
+| List of deleted/modified snapshots | CloudTrail `DeleteSnapshot` events | IR ticket |
+| S3 bucket versioning status | `aws s3api get-bucket-versioning` for affected buckets | IR ticket |
+| S3 deleted object versions | `aws s3api list-object-versions --bucket ... --prefix ...` | Forensic S3 bucket |
+| AWS Backup recovery point inventory | `aws backup list-recovery-points-by-backup-vault` | IR ticket |
+| Ransom note content | Download from S3 / screenshot from email | Forensic S3 bucket (legal hold) |
+| EBS volume encryption status | `aws ec2 describe-volumes --filters Name=encrypted,Values=true` | IR ticket |
+| IAM credential report | `aws iam generate-credential-report` | IR ticket |
+| Billing/Cost Explorer anomalies | AWS Cost Explorer — filter by KMS, EC2, S3 | IR ticket |
+
+**CloudTrail / Athena investigation queries:**
+
+For detailed Athena queries to investigate ransomware activity (KMS operations, bulk deletions, snapshot manipulation, S3 versioning changes, backup vault operations), see:
+
+📁 [`resources/athena-queries-ransomware.sql`](resources/athena-queries-ransomware.sql)
+
+These queries cover:
+- KMS key creation and encryption operations by a suspected principal
+- Bulk deletion activity across S3, EBS, RDS, and AWS Backup
+- Snapshot operations (deletion, cross-account sharing, copying)
+- S3 versioning suspension and Object Lock modifications
+- Ransom note file uploads (common filename patterns)
+- RDS/Aurora snapshot and backup destruction
+- AWS Backup recovery point deletion attempts (including Vault Lock blocks)
+
+### 2.3 Severity Determination
+
+| Confirmed? | Priority Assignment |
+|---|---|
+| Active encryption/deletion in progress, threat actor still has access, production impacted | P1 |
+| Confirmed data destruction, threat actor access revoked, backup integrity uncertain | P1 |
+| Bulk destructive API calls detected, threat actor contained, backups confirmed intact | P2 |
+| Ransom demand received, no confirmed technical action, investigation ongoing | P2 |
+| Anomalous KMS/deletion activity, single non-production account, no confirmed data loss | P3 |
+| Post-incident analysis or ransom demand with no evidence of compromise | P4 |
+
+### 2.4 Getting Help from AWS
+
+> 📌 **If your organization has the AWS Security Incident Response service enabled, or has AWS Support, you can request assistance from the AWS Customer Incident Response Team (CIRT).**
+
+For P1, P2, or P3 incidents, consider engaging AWS for support. Ransomware recovery is complex and time-sensitive — AWS CIRT can help validate backup integrity, advise on recovery sequencing, and provide threat intelligence on the threat actor.
+
+- **If you have the AWS Security Incident Response service enabled:** Sign into [AWS Security Incident Response](https://console.aws.amazon.com/security-ir/) via the console, choose **Create Case**, select **Resolve case with AWS**, and choose **Active Security Incident** for urgent incident response support. This provides direct access to AWS Security Incident Response engineers for containment guidance, backup validation, and recovery sequencing.
+- **If you need assistance from AWS CIRT:** Open a support case with Critical severity and request assistance from the AWS Customer Incident Response Team (CIRT). Include relevant finding IDs and a summary of what you have observed.
+
+> 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
+
+AWS CIRT can assist with:
+- Scoping the extent of destructive operations
+- Validating backup integrity and advising on recovery sequencing
+- Providing threat intelligence on the threat actor's tactics
+- Advising on containment strategy for active encryption/deletion
+- Supporting regulatory notification decisions with technical evidence
+
+> 🤖 **Automation opportunity:** Security Hub custom actions can auto-create Security Incident Response cases when GuardDuty generates malware findings or when bulk deletion patterns are detected.
+
+---
+
+## Part 3 — Contain
+
+> **CSF 2.0 Function:** Respond (Contain)
+> **Goal:** Stop the spread of the incident and prevent further damage without destroying evidence.
+
+### 3.1 Containment Decision
+
+For ransomware, containment speed is paramount. Every minute of delay means more data encrypted or deleted. Unlike other incident types where you may investigate before acting, active data destruction requires immediate action.
+
+```
+Is active encryption/deletion in progress?
+│
+├── YES (threat actor still active)
+│     └── IMMEDIATE containment — proceed to 3.2 without waiting for authorization
+│         (IR Lead has standing authority for P1 ransomware containment)
+│
+└── NO (threat actor appears inactive or already contained)
+      └── Has the compromised credential been revoked?
+            ├── YES → Proceed to 3.2 for defensive hardening
+            └── NO  → Revoke credential FIRST (see IRP-CredCompromise), then proceed
+```
+
+> ⚠️ **For active ransomware (P1), containment takes priority over evidence collection.** You can reconstruct the attack timeline from CloudTrail after the fact. You cannot recover data that has been encrypted with a threat actor-controlled key and then had the key deleted.
+
+### 3.2 Containment Actions
+
+> `[IR Lead]` coordinates. For P1 active ransomware, IR Lead has standing authority to execute Steps 1–4 without waiting for Account Owner approval.
+
+**Step 1: Revoke threat actor access (if not already done)**
+
+If the compromised credential has not yet been contained via IRP-CredCompromise, immediately disable the credential and attach an explicit deny:
+
+```bash
+# Disable the compromised access key
+aws iam update-access-key --access-key-id AKIAIOSFODNN7EXAMPLE \
+  --status Inactive --user-name compromised-user
+
+# Attach explicit deny-all policy to the compromised principal
+aws iam attach-user-policy --user-name compromised-user \
+  --policy-arn arn:aws:iam::123456789012:policy/DenyAll
+
+# Revoke all active sessions for the compromised role (if role-based)
+aws iam put-role-policy --role-name compromised-role \
+  --policy-name RevokeOlderSessions \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Deny",
+      "Action": "*",
+      "Resource": "*",
+      "Condition": {
+        "DateLessThan": {"aws:TokenIssueTime": "2026-05-28T12:00:00Z"}
+      }
+    }]
+  }'
+```
+
+**Step 2: Deploy emergency SCP to block destructive actions org-wide**
+
+Apply this SCP to the affected OU (or root, if scope is unclear) to prevent further destruction even if additional credentials are compromised. This is the broadest containment lever — it stops all destructive actions regardless of which principal is performing them:
+
+```bash
+# Create and attach emergency SCP
+aws organizations create-policy \
+  --name "EmergencyRansomwareContainment" \
+  --type SERVICE_CONTROL_POLICY \
+  --description "Emergency: Block destructive actions during ransomware incident" \
+  --content '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "DenyDestructiveActions",
+        "Effect": "Deny",
+        "Action": [
+          "kms:CreateKey",
+          "kms:ScheduleKeyDeletion",
+          "kms:DisableKey",
+          "kms:CreateGrant",
+          "ec2:DeleteSnapshot",
+          "rds:DeleteDBSnapshot",
+          "rds:DeleteDBClusterSnapshot",
+          "s3:DeleteObject*",
+          "s3:PutBucketVersioning",
+          "backup:DeleteRecoveryPoint",
+          "backup:DeleteBackupVault"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "StringNotLike": {
+            "aws:PrincipalArn": [
+              "arn:aws:iam::*:role/IncidentResponseBreakGlass"
+            ]
+          }
+        }
+      }
+    ]
+  }'
+
+# Attach to affected OU
+aws organizations attach-policy \
+  --policy-id p-EXAMPLE123 \
+  --target-id ou-EXAMPLE
+```
+
+> ⚠️ **This SCP will block legitimate operations.** Document the time applied and plan for removal once the incident is contained.
+
+**Step 3: Network isolation for affected EC2 instances**
+
+If ransomware is executing as a process on EC2 instances, isolate them via security group swap. This cuts C2 communication and lateral movement while preserving the instance for forensics:
+
+```bash
+# Create forensic isolation security group (if not pre-created)
+aws ec2 create-security-group \
+  --group-name forensic-isolation \
+  --description "IR: No inbound/outbound - forensic isolation" \
+  --vpc-id vpc-EXAMPLE
+
+# The group has no rules by default (deny all) — that's the desired state
+
+# Apply to affected instances (replaces all existing security groups)
+aws ec2 modify-instance-attribute \
+  --instance-id i-1234567890abcdef0 \
+  --groups sg-forensic-isolation
+```
+
+> ⚠️ Do NOT stop or terminate instances. Stopping an instance with an instance-store volume will destroy volatile evidence. Isolation via security group swap preserves the instance state.
+
+**Step 4: Preserve snapshots (copy to forensic account)**
+
+Immediately copy any remaining EBS snapshots and RDS snapshots to a forensic account before the threat actor can delete them. This is your safety net if primary backups are compromised:
+
+```bash
+# Copy EBS snapshot to forensic account (cross-account)
+aws ec2 modify-snapshot-attribute \
+  --snapshot-id snap-EXAMPLE \
+  --attribute createVolumePermission \
+  --operation-type add \
+  --user-ids 999888777666  # Forensic account ID
+
+# From the forensic account — copy the snapshot
+aws ec2 copy-snapshot \
+  --source-region us-east-1 \
+  --source-snapshot-id snap-EXAMPLE \
+  --description "IR-preserved: ransomware incident 2026-06-18"
+
+# Copy RDS snapshot to forensic account
+aws rds copy-db-snapshot \
+  --source-db-snapshot-identifier arn:aws:rds:us-east-1:123456789012:snapshot:my-snapshot \
+  --target-db-snapshot-identifier ir-preserved-snapshot-2026-06-18 \
+  --kms-key-id arn:aws:kms:us-east-1:999888777666:key/forensic-key-id
+```
+
+**Step 5: Lock remaining EBS snapshots**
+
+Apply EBS Snapshots Lock to prevent deletion of any remaining snapshots. Compliance mode locks cannot be removed early — even by an administrator:
+
+```bash
+# Lock snapshot in compliance mode (cannot be unlocked early)
+aws ec2 lock-snapshot \
+  --snapshot-id snap-EXAMPLE \
+  --lock-mode compliance \
+  --lock-duration 30  # days — adjust based on investigation timeline
+```
+
+**Step 6: Disable delete operations on critical S3 buckets**
+
+Apply a bucket policy that denies delete operations from all principals except the IR break-glass role. This stops ongoing S3 destruction immediately:
+
+```bash
+aws s3api put-bucket-policy --bucket critical-data-bucket \
+  --policy '{
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Sid": "DenyDeleteDuringIncident",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": ["s3:DeleteObject", "s3:DeleteObjectVersion", "s3:PutBucketVersioning"],
+      "Resource": [
+        "arn:aws:s3:::critical-data-bucket",
+        "arn:aws:s3:::critical-data-bucket/*"
+      ],
+      "Condition": {
+        "StringNotLike": {
+          "aws:PrincipalArn": "arn:aws:iam::123456789012:role/IncidentResponseBreakGlass"
+        }
+      }
+    }]
+  }'
+```
+
+> 🤖 **Automation opportunity:** An EventBridge rule triggered by GuardDuty `Impact:S3/AnomalousBehavior.Delete` findings can automatically apply protective bucket policies. See [Appendix D](#appendix-d--automation-hooks).
+
+### 3.3 Document Containment Actions
+
+After containment begins, document what was done and verify evidence is preserved:
+
+- [ ] EBS snapshots taken for all affected EC2 instances (before any recovery actions)
+- [ ] Remaining EBS snapshots locked with EBS Snapshots Lock (compliance mode)
+- [ ] RDS/Aurora snapshots copied to forensic account
+- [ ] S3 object versions preserved (verify versioning was not successfully suspended)
+- [ ] CloudTrail logs exported to forensic S3 bucket with Object Lock
+- [ ] Threat actor-created KMS key policies captured (`aws kms get-key-policy`)
+- [ ] Ransom note files preserved (do not delete — evidence)
+- [ ] AWS Backup recovery points inventory documented
+- [ ] CloudTrail integrity validation confirmed on exported logs
+- [ ] Timeline of containment actions documented in IR ticket (what was done, when, by whom)
+
+---
+
+## Part 4 — Eradicate & Recover
+
+> **CSF 2.0 Function:** Respond (Eradicate) · Recover
+> **Goal:** Remove the root cause, validate the environment is clean, and restore normal operations.
+
+### 4.1 Root Cause Identification
+
+> `[IR Lead]` owns this step. Document findings in the IR ticket in real time.
+
+Common root causes for cloud-native ransomware:
+
+- **Compromised IAM credentials** — Long-term access keys exposed via phishing, public repository, or credential stuffing (most common)
+- **Overly permissive IAM policies** — PowerUserAccess or AdministratorAccess on principals that don't require it
+- **Missing preventive controls** — No SCPs blocking destructive actions, no Backup Vault Lock, no S3 Object Lock
+- **Compromised EC2 instance role** — Malware on an instance leveraging the instance metadata service to obtain role credentials
+- **Third-party integration compromise** — SaaS tool or CI/CD pipeline with excessive AWS permissions compromised
+- **Insider threat** — Disgruntled employee or contractor with legitimate access performing destructive actions
+
+> 📌 This is not an exhaustive list. Root causes vary by environment and threat actor. Use evidence from Part 2 to identify the specific initial access vector for your incident.
+
+Use evidence collected in Part 2 to trace:
+1. Initial access vector (how did the threat actor get credentials?)
+2. Privilege escalation path (how did they get destructive permissions?)
+3. Full scope of destructive actions (what was encrypted/deleted?)
+4. Persistence mechanisms (are there additional backdoors?)
+
+### 4.2 Eradication Actions
+
+> `[IR Lead]` coordinates. `[Account Owner]` approves changes to production resources.
+
+1. **Remove threat actor persistence mechanisms**
+   Check for and remove:
+   - [ ] Unauthorized IAM users, roles, or access keys created during incident
+   - [ ] Threat actor-created KMS keys and grants (document key IDs before deletion)
+   - [ ] Unauthorized Lambda functions or EC2 instances (potential C2 or re-encryption tools)
+   - [ ] Modified resource policies (S3 bucket policies, KMS key policies, trust relationships)
+   - [ ] Modified SCPs or permission boundaries
+   - [ ] Unauthorized CloudFormation stacks or Terraform state modifications
+   - [ ] EventBridge rules or scheduled actions created by threat actor
+
+   > 📌 **This list is not exhaustive.** Threat actors employ many persistence techniques beyond those listed here. For a comprehensive reference of persistence mechanisms observed in AWS environments, see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
+
+2. **Rotate all credentials in affected accounts**
+   ```bash
+   # Generate new access keys for legitimate users (after deleting compromised ones)
+   aws iam create-access-key --user-name legitimate-user
+   
+   # Force password reset for all console users in affected account
+   # (Coordinate with Account Owner — this will disrupt users)
+   ```
+
+3. **Validate KMS key integrity**
+   - Confirm all legitimate KMS keys are still enabled and accessible
+   - Verify key policies have not been modified to grant threat actor access
+   - If threat actor scheduled key deletion, cancel it immediately:
+   ```bash
+   aws kms cancel-key-deletion --key-id arn:aws:kms:us-east-1:123456789012:key/KEY_ID
+   aws kms enable-key --key-id arn:aws:kms:us-east-1:123456789012:key/KEY_ID
+   ```
+
+4. **Remove emergency containment controls (when safe)**
+   - Remove emergency SCP (replace with permanent preventive SCPs)
+   - Remove emergency bucket policies (replace with proper access controls)
+   - Restore security groups on isolated instances (only after forensics complete)
+
+> 🤖 **Automation opportunity:** AWS Config auto-remediation rules can detect unauthorized IAM resources and automatically delete them. Use with caution during active incidents.
+
+### 4.3 Recovery Decision: Backup-First Approach
+
+> `[IR Lead]` provides technical assessment of backup integrity. Payment decisions are outside the scope of this playbook — consult your organization's Legal counsel and cyber insurance provider.
+
+```
+Can we recover from backups?
+│
+├── YES — Backups confirmed intact (Vault Lock / Object Lock / cross-account copies)
+│     └── Proceed to recovery from backups (Section 4.4)
+│
+└── NO or UNCERTAIN — Backups may be compromised or incomplete
+      │
+      └── Can we validate backup integrity?
+            ├── YES → Test restore in isolated environment
+            │           ├── Restore successful → Proceed to 4.4
+            │           └── Restore failed or incomplete → See below
+            └── NO  → See below
+```
+
+**If backups are unavailable or incomplete:**
+
+- Engage your organization's **Legal counsel** and **cyber insurance provider** immediately. Payment decisions involve legal, regulatory, and business considerations that are outside the scope of technical incident response.
+- Continue all technical recovery efforts in parallel — exhaust every backup and restore option before concluding that data is unrecoverable.
+- Engage **AWS CIRT** (via support case) for assistance identifying any remaining recovery paths (cross-region snapshots, S3 versioned objects, Backup recovery points in other vaults).
+- Report to **law enforcement** (FBI IC3 or local CERT) — coordinate through Legal.
+
+> 📌 **The strongest defense against ransom payment is preparation.** AWS Backup Vault Lock (compliance mode), S3 Object Lock, and EBS Snapshots Lock ensure that backups cannot be deleted or modified — even by an administrator with full account access. Investing in immutable backups before an incident ensures that payment is never a consideration during one.
+
+### 4.4 Recovery Actions
+
+Recovery is often the most complex phase of a ransomware incident. Multiple recovery methods may be needed depending on which services were affected and what backup mechanisms were in place. The priority order is: (1) Validate backup integrity, (2) Restore critical workloads, (3) Restore supporting services, (4) Validate and harden.
+
+**Recovery Method 1: AWS Backup (with Vault Lock validation)**
+
+If AWS Backup Vault Lock (compliance mode) is enabled, recovery points in that vault are guaranteed to be unmodified. This is the fastest path to confident recovery:
+
+```bash
+# List recovery points in the vault-locked backup vault
+aws backup list-recovery-points-by-backup-vault \
+  --backup-vault-name production-vault-locked
+
+# Verify vault lock status (compliance mode = immutable)
+aws backup describe-backup-vault \
+  --backup-vault-name production-vault-locked
+# Confirm: "Locked": true, "LockDate": <date>, "MinRetentionDays": <value>
+
+# Start restore job (EBS volume example)
+aws backup start-restore-job \
+  --recovery-point-arn arn:aws:ec2:us-east-1::snapshot/snap-EXAMPLE \
+  --iam-role-arn arn:aws:iam::123456789012:role/AWSBackupRestoreRole \
+  --metadata '{"availabilityZone":"us-east-1a","encrypted":"true","kmsKeyId":"arn:aws:kms:us-east-1:123456789012:key/LEGITIMATE-KEY-ID"}'
+
+# Start restore job (RDS example)
+aws backup start-restore-job \
+  --recovery-point-arn arn:aws:rds:us-east-1:123456789012:snapshot:awsbackup-EXAMPLE \
+  --iam-role-arn arn:aws:iam::123456789012:role/AWSBackupRestoreRole \
+  --metadata '{"DBInstanceClass":"db.r5.large","DBInstanceIdentifier":"restored-production-db","MultiAZ":"true"}'
+```
+
+**Recovery Method 2: S3 versioning (restoring previous object versions)**
+
+If versioning was enabled and the threat actor deleted current versions or uploaded ransom notes, previous versions may still be retrievable:
+
+```bash
+# List object versions to find pre-attack versions
+aws s3api list-object-versions \
+  --bucket affected-bucket \
+  --prefix important-data/ \
+  --max-keys 1000
+
+# Restore a specific previous version (copy it as the current version)
+aws s3api copy-object \
+  --bucket affected-bucket \
+  --key important-data/file.dat \
+  --copy-source "affected-bucket/important-data/file.dat?versionId=PRE_ATTACK_VERSION_ID"
+
+# Bulk restore script (for many objects):
+# List all delete markers created during the attack window and remove them
+aws s3api list-object-versions \
+  --bucket affected-bucket \
+  --prefix important-data/ \
+  --query "DeleteMarkers[?LastModified>='2026-06-18T10:00:00' && LastModified<='2026-06-18T14:00:00'].{Key:Key,VersionId:VersionId}" \
+  --output json > delete_markers_to_remove.json
+
+# Then iterate and remove each delete marker to "undelete" objects
+# (Use a script — see Appendix D for automation)
+```
+
+**Recovery Method 3: EBS snapshot restore**
+
+For EC2 workloads where volumes were encrypted with a threat actor-controlled KMS key, restore from pre-attack snapshots:
+
+```bash
+# Create volume from pre-attack snapshot
+aws ec2 create-volume \
+  --snapshot-id snap-PRE_ATTACK_SNAPSHOT \
+  --availability-zone us-east-1a \
+  --volume-type gp3 \
+  --encrypted \
+  --kms-key-id arn:aws:kms:us-east-1:123456789012:key/LEGITIMATE-KEY-ID
+
+# Detach compromised volume and attach restored volume
+aws ec2 detach-volume --volume-id vol-COMPROMISED --instance-id i-EXAMPLE
+aws ec2 attach-volume --volume-id vol-RESTORED --instance-id i-EXAMPLE --device /dev/sda1
+```
+
+**Recovery Method 4: RDS point-in-time recovery**
+
+For databases where snapshots were deleted or the instance was modified, point-in-time recovery allows restoration to any second within the backup retention window:
+
+```bash
+# Restore to a point in time before the attack
+aws rds restore-db-instance-to-point-in-time \
+  --source-db-instance-identifier production-db \
+  --target-db-instance-identifier production-db-restored \
+  --restore-time "2026-06-18T09:00:00Z" \
+  --db-instance-class db.r5.large \
+  --multi-az
+
+# For Aurora clusters
+aws rds restore-db-cluster-to-point-in-time \
+  --source-db-cluster-identifier production-cluster \
+  --db-cluster-identifier production-cluster-restored \
+  --restore-to-time "2026-06-18T09:00:00Z" \
+  --engine aurora-postgresql
+```
+
+**Recovery Method 5: AWS Elastic Disaster Recovery failover**
+
+For workloads configured with AWS Elastic Disaster Recovery (DRS), this provides the fastest RTO for full-instance recovery:
+
+```bash
+# Initiate recovery launch for affected source servers
+aws drs start-recovery \
+  --source-servers '[{"sourceServerID": "s-1234567890abcdef0"}]' \
+  --is-drill false
+
+# Monitor recovery job status
+aws drs describe-jobs --filters '{"jobIDs": ["j-EXAMPLE"]}'
+```
+
+> ⚠️ Elastic Disaster Recovery provides the fastest RTO for full-instance recovery. If configured, prefer this method for EC2 workloads over manual snapshot restore.
+
+### 4.5 Recovery Validation
+
+Confirm the environment is clean and functional before declaring the incident resolved.
+
+- [ ] All restored data validated for integrity (checksums, application-level validation)
+- [ ] No unauthorized resources remain in affected accounts
+- [ ] All threat actor-created KMS keys disabled or deleted (after confirming they're not needed for evidence)
+- [ ] All credentials created or used by threat actor have been revoked
+- [ ] Legitimate KMS keys confirmed accessible and functional
+- [ ] Application and service health metrics are within normal range
+- [ ] Database connectivity and query results validated
+- [ ] S3 bucket versioning re-enabled (if it was suspended by threat actor)
+- [ ] GuardDuty / Security Hub show no active findings related to this incident
+- [ ] Emergency SCP removed and replaced with permanent preventive controls
+- [ ] Monitoring and alerting confirmed operational
+- [ ] AWS Backup jobs running successfully on restored resources
+- [ ] AWS Security Incident Response case updated (if applicable)
+
+### 4.6 Harden Against Recurrence
+
+- [ ] Enable AWS Backup Vault Lock (compliance mode) on all backup vaults containing critical data
+- [ ] Enable S3 Object Lock on buckets containing critical data
+- [ ] Enable EBS Snapshots Lock on critical snapshots
+- [ ] Implement SCPs to prevent disabling of versioning, Vault Lock, and Object Lock in production OUs
+- [ ] Restrict KMS `CreateKey` and `ScheduleKeyDeletion` permissions to authorized principals only
+- [ ] Enable MFA Delete on S3 buckets containing critical data
+- [ ] Implement least-privilege IAM — remove PowerUserAccess and AdministratorAccess from non-admin principals
+- [ ] Configure AWS Elastic Disaster Recovery for critical workloads (if not already)
+- [ ] Enable cross-account and cross-region backup copies
+- [ ] Implement backup integrity testing (automated restore validation)
+
+---
+
+## Part 5 — Post-Incident Activity
+
+> **CSF 2.0 Function:** Identify (Improve) — continuous improvement, not a one-time activity
+> **Goal:** Learn from this incident to reduce the likelihood and impact of future occurrences.
+
+### 5.1 Timeline Reconstruction
+
+Build a complete timeline of the incident from initial compromise through recovery. This should be completed within 24–48 hours while events are fresh and CloudTrail data is readily queryable. A clear timeline supports post-incident review, regulatory inquiries, and future detection tuning.
+
+| Timestamp (UTC) | Event | Source / Evidence | Actor |
+|---|---|---|---|
+| YYYY-MM-DD HH:MM | Initial credential compromise | CloudTrail / phishing report | Threat actor |
+| YYYY-MM-DD HH:MM | Threat actor-controlled KMS key created | CloudTrail `kms:CreateKey` | Threat actor |
+| YYYY-MM-DD HH:MM | EBS volume encryption began | CloudTrail `ec2:CreateSnapshot`, `kms:Encrypt` | Threat actor |
+| YYYY-MM-DD HH:MM | S3 versioning suspended on buckets | CloudTrail `s3:PutBucketVersioning` | Threat actor |
+| YYYY-MM-DD HH:MM | Bulk S3 object deletion began | CloudTrail `s3:DeleteObject` | Threat actor |
+| YYYY-MM-DD HH:MM | RDS snapshots deleted | CloudTrail `rds:DeleteDBSnapshot` | Threat actor |
+| YYYY-MM-DD HH:MM | Ransom note uploaded to S3 | CloudTrail `s3:PutObject` | Threat actor |
+| YYYY-MM-DD HH:MM | GuardDuty finding generated | GuardDuty | AWS |
+| YYYY-MM-DD HH:MM | IR team notified | On-call alert | IR Lead |
+| YYYY-MM-DD HH:MM | Credential revoked | CloudTrail `iam:UpdateAccessKey` | IR Lead |
+| YYYY-MM-DD HH:MM | Emergency SCP deployed | CloudTrail `organizations:AttachPolicy` | IR Lead |
+| YYYY-MM-DD HH:MM | Containment confirmed | IR ticket | IR Lead |
+| YYYY-MM-DD HH:MM | Recovery from backup initiated | AWS Backup console | Backup Admin |
+| YYYY-MM-DD HH:MM | Recovery validated, services restored | Application monitoring | IR Lead |
+
+**Key metrics:**
+
+These metrics help you measure response effectiveness over time and identify where investment would reduce future incident duration or data loss.
+
+| Metric | Value | Why It Matters |
+|---|---|---|
+| Time to Detect (TTD) | *HH:MM from initial destructive action to detection* | Measures detection coverage — every minute undetected is more data lost |
+| Time to Notify (TTN) | *HH:MM from detection to IR team notified* | Measures alerting pipeline effectiveness |
+| Time to Contain (TTC) | *HH:MM from notification to threat actor access revoked* | Measures response readiness — the critical window for ransomware |
+| Time to Recover (TTR) | *HH:MM from containment to services restored* | Measures backup posture and recovery process maturity |
+| Total Incident Duration | *HH:MM* | End-to-end impact window |
+| Data Loss Window | *Time between last good backup and attack start* | Measures backup frequency adequacy — drives RPO decisions |
+| Resources Affected | *Count: EBS volumes, S3 buckets, RDS instances, snapshots deleted* | Blast radius |
+| Data Impact | *Confirmed / Suspected / None — quantify GB/TB if possible* | Drives regulatory notification and business impact assessment |
+| Recovery Method Used | *Backup Vault Lock / S3 Versioning / Snapshot / DRS / Other* | Validates which investments paid off |
+| Ransom Paid | *Yes / No — if yes, document amount and outcome* | Organizational record |
+
+### 5.2 Post-Incident Review
+
+Conduct a blameless post-incident review within **3 business days** for P1, **5 business days** for P2, **15 business days** for P3/P4. The goal is to identify systemic improvements — particularly to backup posture and preventive controls — not to assign blame.
+
+Discussion questions specific to ransomware:
+
+1. What was the initial access vector? Could it have been prevented with existing controls?
+2. Did the threat actor have more permissions than necessary? Would least-privilege have limited the scope of impact?
+3. Were immutable backups (Vault Lock, Object Lock) in place for all critical data? If not, why not?
+4. How quickly was the attack detected? Could detection have been faster with better monitoring?
+5. Were containment actions effective? Did the emergency SCP deploy quickly enough?
+6. Was the recovery process smooth? Were there gaps in backup coverage?
+7. Did the team know where to find backups and how to restore? Was documentation adequate?
+8. Were communication and escalation paths clear? Did Legal and Executive Sponsor engage at the right time?
+9. What single preventive control would have most reduced the impact of this incident?
+10. Is our backup strategy adequate? Do we need to expand Vault Lock / Object Lock coverage?
+11. Were our preparation steps (Part 1) adequate? Did we have the access, tools, and documentation we needed?
+
+### 5.3 Detection Gap Analysis
+
+For each gap identified during the incident — whether a detection that didn't fire, an alert that wasn't actioned, or a blind spot in backup coverage — document the root cause and assign an owner to fix it.
+
+| Gap | Root Cause | Recommended Fix | Owner | Target Date |
+|---|---|---|---|---|
+| *(e.g., Bulk deletion not detected for 2 hours)* | *(No CloudWatch alarm on S3 delete volume)* | *(Create alarm for >100 deletes/hour)* | | |
+| *(e.g., KMS key creation not alerted)* | *(No EventBridge rule for CreateKey)* | *(Deploy EventBridge rule + SNS alert)* | | |
+| *(e.g., Versioning suspension not detected)* | *(No Config rule for versioning status)* | *(Enable `s3-bucket-versioning-enabled` rule)* | | |
+| *(e.g., No alert on snapshot deletion)* | *(GuardDuty doesn't cover this natively)* | *(Custom EventBridge rule for DeleteSnapshot)* | | |
+
+### 5.4 Playbook Update Checklist
+
+Use this incident to improve this playbook. Do not wait for the next scheduled review — update immediately while the gaps are clear.
+
+- [ ] Were triage questions sufficient? Add/remove as needed.
+- [ ] Were evidence collection steps accurate for this scenario?
+- [ ] Were containment actions effective? Update steps if not.
+- [ ] Were recovery procedures accurate? Update with lessons learned.
+- [ ] Was the recovery decision tree useful? Refine based on actual decision process.
+- [ ] Were any automation opportunities identified? Add to Appendix D.
+- [ ] Were severity criteria accurate? Adjust if incidents were under- or over-classified.
+- [ ] Update **Last Reviewed** date and increment **Playbook Version**.
+
+---
+
+## Appendix A — Investigation Resources
+
+For detailed Athena queries, GuardDuty CLI commands, and CloudTrail investigation patterns relevant to ransomware investigations, see:
+
+📁 [`resources/athena-queries-ransomware.sql`](resources/athena-queries-ransomware.sql)
+
+These queries cover:
+- KMS key creation and encryption operations by a suspected principal
+- Bulk deletion activity across S3, EBS, RDS, and AWS Backup (with anomaly detection)
+- Snapshot operations — deletion, cross-account sharing, copying
+- S3 versioning suspension and Object Lock modifications
+- Ransom note file uploads (common filename patterns)
+- RDS/Aurora snapshot and backup destruction
+- AWS Backup recovery point deletion attempts (including Vault Lock blocks)
+
+**GuardDuty Finding Export (CLI):**
+
+```bash
+# List malware and impact findings
+aws guardduty list-findings \
+  --detector-id DETECTOR_ID \
+  --finding-criteria '{
+    "Criterion": {
+      "type": {
+        "Eq": ["Execution:EC2/MaliciousFile", "Impact:S3/AnomalousBehavior.Delete",
+               "Impact:S3/AnomalousBehavior.Write"]
+      },
+      "severity": {"Gte": 7}
+    }
+  }' \
+  --region us-east-1
+
+# Get full finding details
+aws guardduty get-findings \
+  --detector-id DETECTOR_ID \
+  --finding-ids FINDING_ID_1 FINDING_ID_2
+```
+
+---
+
+## Appendix B — Regulatory & Compliance Considerations
+
+> `[Legal / Compliance]` owns this section during an active incident.
+
+Ransomware incidents trigger notification obligations under most regulatory frameworks because they involve both a security breach (unauthorized access) and potential data loss (availability impact). Even if no data was exfiltrated, the loss of availability alone may trigger notification requirements.
+
+**Quick reference for ransomware scenarios:**
+
+| Regulation / Framework | Trigger Condition | Timeframe | Notes |
+|---|---|---|---|
+| **GDPR Art. 33/34** | Personal data unavailable due to encryption/deletion (availability breach) | 72 hours to supervisory authority; "without undue delay" to data subjects if high risk | Ransomware is explicitly called out in EDPB guidance as a notifiable breach even without exfiltration |
+| **HIPAA Breach Notification** | ePHI encrypted or destroyed by unauthorized party | 60 days to HHS; 60 days to individuals; media if >500 affected | Presumed breach unless low probability of compromise demonstrated |
+| **PCI DSS v4.0 (Req. 12.10)** | Cardholder data environment affected | Immediately to acquirer and card brands | May trigger forensic investigation requirement (PFI) |
+| **SOC 2 (Trust Services Criteria)** | Availability or confidentiality criteria impacted | Per engagement terms | Document in management assertion; notify auditor |
+| **SEC Cybersecurity Rules (2023)** | Material cybersecurity incident | 4 business days (Form 8-K) | Materiality determination required — ransomware with significant operational impact likely qualifies |
+| **NIS2 Directive (EU)** | Significant incident affecting essential/important entity | 24 hours early warning; 72 hours incident notification | Ransomware causing service disruption meets "significant incident" threshold |
+| **PIPEDA (Canada)** | Real risk of significant harm from breach | "As soon as feasible" to Privacy Commissioner and affected individuals | Encryption/destruction of personal information qualifies |
+| **Australian NDB Scheme** | Eligible data breach involving personal information | 30 days to OAIC; "as soon as practicable" to individuals | Loss of access to personal information through ransomware is an eligible breach |
+| **DORA (EU Financial)** | Major ICT-related incident | 4 hours initial notification; 72 hours intermediate report | Financial entities — ransomware disrupting services is a major ICT incident |
+| **State Breach Laws (US)** | Personal information of state residents affected | Varies by state (24 hours to 60 days) | Check each applicable state; some require AG notification |
+| **CISA Reporting (CIRCIA)** | Covered entity experiences substantial cyber incident | 72 hours (when final rule effective) | Ransomware payment: 24 hours |
+
+> ⚠️ The clock starts at **awareness**, not confirmation. When in doubt, assume notification is required and consult Legal immediately. For ransomware, the availability impact alone (inability to access data) is sufficient to trigger most frameworks — you do not need to prove exfiltration.
+
+> ⚠️ **Ransom payments** have additional reporting requirements. CISA requires reporting within 24 hours. OFAC sanctions screening is mandatory before any payment. Consult Legal before any payment decision.
+
+---
+
+## Appendix C — Reference Links
+
+- [NIST SP 800-61r3 — Incident Response Recommendations and Considerations for Cybersecurity Risk Management](https://csrc.nist.gov/pubs/sp/800/61/r3/final)
+- [AWS Security Incident Response Guide](https://docs.aws.amazon.com/whitepapers/latest/aws-security-incident-response-guide/aws-security-incident-response-guide.html)
+- [AWS Security Incident Response Service Documentation](https://docs.aws.amazon.com/security-ir/latest/userguide/what-is-security-ir.html)
+- [AWS Well-Architected Framework — Security Pillar: Incident Response](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/incident-response.html)
+- [AWS Well-Architected Framework — Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Amazon GuardDuty Finding Types](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-active.html)
+- [Amazon GuardDuty Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html)
+- [AWS Backup Vault Lock](https://docs.aws.amazon.com/aws-backup/latest/devguide/vault-lock.html)
+- [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html)
+- [EBS Snapshots Lock](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-snapshot-lock.html)
+- [AWS Elastic Disaster Recovery](https://docs.aws.amazon.com/drs/latest/userguide/what-is-drs.html)
+- [AWS KMS Key Management Best Practices](https://docs.aws.amazon.com/kms/latest/developerguide/best-practices.html)
+- [CISA #StopRansomware Guide](https://www.cisa.gov/stopransomware)
+- [NIST Cybersecurity Framework 2.0](https://www.nist.gov/cyberframework)
+- [AWS CloudTrail Query Examples (Athena)](https://docs.aws.amazon.com/athena/latest/ug/cloudtrail-logs.html)
+- [AWS Organizations — Service Control Policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html)
+- [AWS CIRT Incident Response Workshops](https://aws.amazon.com/blogs/security/aws-cirt-announces-the-release-of-five-publicly-available-workshops/)
+
+---
+
+## Appendix D — Automation Hooks
+
+### EventBridge Rule: Auto-Snapshot on GuardDuty Malware Finding
+
+When GuardDuty detects malware on an EC2 instance, automatically create EBS snapshots of all attached volumes to preserve the pre-encryption state.
+
+**EventBridge Rule Pattern:**
+```json
+{
+  "source": ["aws.guardduty"],
+  "detail-type": ["GuardDuty Finding"],
+  "detail": {
+    "type": [
+      {"prefix": "Execution:EC2/MaliciousFile"},
+      {"prefix": "Execution:EC2/SuspiciousFile"},
+      {"prefix": "CryptoCurrency:EC2/BitcoinTool"}
+    ],
+    "severity": [{"numeric": [">=", 7]}]
+  }
+}
+```
+
+**Target: Lambda function (or Step Functions state machine)**
+
+```python
+# Lambda function: auto-snapshot on GuardDuty malware finding
+import boto3
+import json
+from datetime import datetime
+
+ec2 = boto3.client('ec2')
+
+def handler(event, context):
+    """Create EBS snapshots for all volumes attached to the affected instance."""
+    
+    detail = event['detail']
+    instance_id = detail['resource']['instanceDetails']['instanceId']
+    finding_id = detail['id']
+    finding_type = detail['type']
+    
+    # Describe instance to get attached volumes
+    response = ec2.describe_instances(InstanceIds=[instance_id])
+    
+    if not response['Reservations']:
+        print(f"Instance {instance_id} not found")
+        return
+    
+    instance = response['Reservations'][0]['Instances'][0]
+    volumes = [bdm['Ebs']['VolumeId'] 
+               for bdm in instance.get('BlockDeviceMappings', [])
+               if 'Ebs' in bdm]
+    
+    snapshot_ids = []
+    for volume_id in volumes:
+        snapshot = ec2.create_snapshot(
+            VolumeId=volume_id,
+            Description=f"IR-AUTO: GuardDuty {finding_type} - {finding_id}",
+            TagSpecifications=[{
+                'ResourceType': 'snapshot',
+                'Tags': [
+                    {'Key': 'CreatedBy', 'Value': 'IR-Automation'},
+                    {'Key': 'GuardDutyFinding', 'Value': finding_id},
+                    {'Key': 'SourceInstance', 'Value': instance_id},
+                    {'Key': 'CreatedAt', 'Value': datetime.utcnow().isoformat()},
+                    {'Key': 'Purpose', 'Value': 'forensic-preservation'}
+                ]
+            }]
+        )
+        snapshot_ids.append(snapshot['SnapshotId'])
+        
+        # Lock the snapshot immediately (governance mode — can be unlocked by IR team)
+        ec2.lock_snapshot(
+            SnapshotId=snapshot['SnapshotId'],
+            LockMode='governance',
+            LockDuration=30  # days
+        )
+    
+    print(f"Created and locked {len(snapshot_ids)} snapshots for instance {instance_id}: {snapshot_ids}")
+    return {'snapshotIds': snapshot_ids, 'instanceId': instance_id}
+```
+
+### EventBridge Rule: Alert on Bulk Deletion Patterns
+
+```json
+{
+  "source": ["aws.s3", "aws.ec2", "aws.rds"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail": {
+    "eventName": [
+      "DeleteObject", "DeleteObjects", "DeleteSnapshot",
+      "DeleteDBSnapshot", "DeleteDBClusterSnapshot",
+      "DeleteRecoveryPoint", "PutBucketVersioning"
+    ]
+  }
+}
+```
+
+**Target:** SNS topic → IR team notification + CloudWatch metric for alarm threshold (>50 delete operations in 5 minutes).
+
+### EventBridge Rule: Alert on KMS Key Creation from Unusual Principal
+
+```json
+{
+  "source": ["aws.kms"],
+  "detail-type": ["AWS API Call via CloudTrail"],
+  "detail": {
+    "eventName": ["CreateKey", "CreateGrant", "ScheduleKeyDeletion"],
+    "userIdentity": {
+      "type": [{"anything-but": "AssumedRole"}]
+    }
+  }
+}
+```
+
+**Target:** SNS topic → immediate IR team notification. Any KMS key creation outside of expected automation roles warrants investigation.
+
+### S3 Bulk Restore Script
+
+For restoring many objects after a ransomware attack that deleted current versions:
+
+```bash
+#!/bin/bash
+# restore_s3_versions.sh — Remove delete markers created during attack window
+# Usage: ./restore_s3_versions.sh <bucket> <prefix> <attack_start> <attack_end>
+
+BUCKET=$1
+PREFIX=$2
+ATTACK_START=$3
+ATTACK_END=$4
+
+echo "Listing delete markers created between ${ATTACK_START} and ${ATTACK_END}..."
+
+aws s3api list-object-versions \
+  --bucket "${BUCKET}" \
+  --prefix "${PREFIX}" \
+  --query "DeleteMarkers[?LastModified>='${ATTACK_START}' && LastModified<='${ATTACK_END}'].[Key,VersionId]" \
+  --output text | while read KEY VERSION_ID; do
+    echo "Removing delete marker: ${KEY} (${VERSION_ID})"
+    aws s3api delete-object \
+      --bucket "${BUCKET}" \
+      --key "${KEY}" \
+      --version-id "${VERSION_ID}"
+done
+
+echo "Restore complete. Verify object accessibility."
+```
+
+---
+
+## Appendix E — Ransomware Attack Patterns in AWS
+
+The patterns below represent common cloud-native ransomware attack chains observed in AWS environments. For a comprehensive catalog of individual techniques (including those not specific to ransomware), see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
+
+### Pattern 1: EBS Volume Encryption
+
+1. Threat actor creates a new KMS key (customer-managed) in the target account
+2. Threat actor creates snapshots of target EBS volumes
+3. Threat actor creates new encrypted volumes from snapshots using threat actor-controlled KMS key
+4. Threat actor swaps volumes on running instances (or stops instances and replaces root volumes)
+5. Threat actor deletes original snapshots and schedules deletion of the KMS key
+6. Threat actor leaves ransom note (often via S3 or instance user data)
+
+**Detection indicators:** Unusual `kms:CreateKey`, `ec2:CreateSnapshot`, `ec2:CopySnapshot` with new KMS key, `ec2:DeleteSnapshot` in rapid succession.
+
+### Pattern 2: S3 Ransomware (Delete + Ransom Note)
+
+1. Threat actor suspends versioning on target buckets (`PutBucketVersioning` with Status: Suspended)
+2. Threat actor deletes all objects in the bucket (or specific high-value prefixes)
+3. Threat actor uploads ransom note files (e.g., `RANSOM_NOTE.txt`, `README_RESTORE.html`)
+4. If versioning was already enabled, threat actor may create delete markers on all objects instead
+
+**Detection indicators:** `PutBucketVersioning` (Suspended), bulk `DeleteObject`/`DeleteObjects`, `PutObject` for ransom note filenames.
+
+### Pattern 3: S3 Ransomware (Server-Side Encryption Swap)
+
+1. Threat actor creates a KMS key with a restrictive key policy (only threat actor can decrypt)
+2. Threat actor copies objects back to the same bucket with new server-side encryption using threat actor's KMS key
+3. Threat actor deletes the original object versions
+4. Data is now encrypted with a key the organization cannot access
+
+**Detection indicators:** `s3:CopyObject` with `x-amz-server-side-encryption-aws-kms-key-id` pointing to an unknown key, followed by version deletion.
+
+### Pattern 4: RDS/Aurora Snapshot Destruction
+
+1. Threat actor deletes automated snapshots (`DeleteDBSnapshot`, `DeleteDBClusterSnapshot`)
+2. Threat actor modifies backup retention to 0 days (disables automated backups)
+3. Threat actor may delete the database instance itself
+4. Without snapshots or backups, recovery is impossible without payment
+
+**Detection indicators:** Bulk `DeleteDBSnapshot`, `ModifyDBInstance` with `BackupRetentionPeriod: 0`, `DeleteDBInstance` with `SkipFinalSnapshot: true`.
+
+### Pattern 5: AWS Backup Destruction
+
+1. Threat actor attempts to delete recovery points from backup vaults
+2. If Vault Lock is not enabled, threat actor deletes recovery points
+3. Threat actor may attempt to delete the backup vault itself
+4. If Vault Lock IS enabled (compliance mode), deletion fails — this is the primary defense
+
+**Detection indicators:** `DeleteRecoveryPoint`, `DeleteBackupVault` (will fail if Vault Lock is enabled — look for `errorCode` in CloudTrail).
+
+---
+
+## Revision History
+
+| Version | Date | Author | Change Summary |
+|---|---|---|---|
+| 1.0 | 2024-03-15 | AWS CIRT | Initial draft — basic ransomware response procedures |
+| 1.1 | 2024-09-01 | AWS CIRT | Added S3 Object Lock and Backup Vault Lock guidance |
+| 2.0 | 2026-05-28 | AWS CIRT | Complete rewrite — NIST SP 800-61r3 alignment, CSF 2.0 mapping, expanded recovery procedures, automation hooks, EBS Snapshots Lock, Elastic Disaster Recovery, regulatory matrix, attack pattern appendix |
+| 2.1 | 2026-06-18 | AWS CIRT | PR2 refresh — context paragraphs added, queries moved to resources file, forward references updated, "threat actor" terminology, SEC10 references, Well-Architected links, escalation path expanded, Game Day resources added, pay/don't-pay messaging fixed |

--- a/playbooks/IRP-Ransomware.md
+++ b/playbooks/IRP-Ransomware.md
@@ -91,7 +91,7 @@ The following services each contribute to your ability to detect, investigate, a
 - [ ] **VPC Flow Logs** enabled for all production VPCs — supports investigation of lateral movement and C2 communication
 
 > 🤖 **Automation opportunity:** Deploy an EventBridge rule that triggers automatic EBS snapshot creation when GuardDuty generates a malware finding for an EC2 instance. This preserves the pre-encryption state. See [Appendix D](#appendix-d--automation-hooks) for implementation.
-
+>
 > 📖 **Reference:** [SEC10-BP06 Pre-deploy tools](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_pre_deploy_tools.html) — AWS Well-Architected Framework recommends pre-deploying investigation and response tooling so capabilities are available immediately when needed.
 
 ### 1.2 IAM & Access Prerequisites
@@ -137,7 +137,7 @@ Clear communication paths reduce confusion during high-pressure incidents. Ranso
 4. **Status updates:** IR Lead provides updates every 15 minutes (P1), every 1 hour (P2), or at key milestones (P3/P4).
 
 > ⚠️ **Ransom payment decisions** require Executive Sponsor and Legal involvement. IR Lead does not have authority to approve or deny payment. Consult your organization's Legal counsel and cyber insurance provider.
-
+>
 > 📖 **Reference:** [SEC10-BP01 Identify key personnel and external resources](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/sec_incident_response_identify_personnel.html) — recommends identifying and documenting internal and external resources and contact information ahead of time.
 
 ### 1.4 Game Day Guidance
@@ -150,6 +150,7 @@ Suggested tabletop scenario:
 > *"A threat actor has compromised an IAM user's access key (obtained from a phishing campaign targeting developers). The key has PowerUserAccess in a production account. Over the past 2 hours, the threat actor has: (1) created a new KMS key in us-east-1, (2) begun re-encrypting EBS volumes attached to production EC2 instances with the threat actor-controlled key, (3) suspended versioning on three S3 buckets and is bulk-deleting objects while uploading RANSOM_NOTE.txt files, and (4) deleted 5 RDS automated snapshots. Your GuardDuty finding fired 15 minutes ago. The threat actor appears to still be active. You have AWS Backup Vault Lock enabled on your primary backup vault, but you're unsure if all critical resources are covered by backup plans."*
 
 Exercise should validate:
+
 - Speed of credential revocation and SCP deployment
 - Backup integrity verification process
 - Cross-account snapshot copy procedures
@@ -215,6 +216,7 @@ For detailed Athena queries to investigate ransomware activity (KMS operations, 
 📁 [`resources/athena-queries-ransomware.sql`](resources/athena-queries-ransomware.sql)
 
 These queries cover:
+
 - KMS key creation and encryption operations by a suspected principal
 - Bulk deletion activity across S3, EBS, RDS, and AWS Backup
 - Snapshot operations (deletion, cross-account sharing, copying)
@@ -246,6 +248,7 @@ For P1, P2, or P3 incidents, consider engaging AWS for support. Ransomware recov
 > 📌 You do not need the Security Incident Response service to get help from AWS CIRT. All AWS customers can request CIRT assistance through a support case, regardless of support plan level.
 
 AWS CIRT can assist with:
+
 - Scoping the extent of destructive operations
 - Validating backup integrity and advising on recovery sequencing
 - Providing threat intelligence on the threat actor's tactics
@@ -265,7 +268,7 @@ AWS CIRT can assist with:
 
 For ransomware, containment speed is paramount. Every minute of delay means more data encrypted or deleted. Unlike other incident types where you may investigate before acting, active data destruction requires immediate action.
 
-```
+```text
 Is active encryption/deletion in progress?
 │
 ├── YES (threat actor still active)
@@ -486,6 +489,7 @@ Common root causes for cloud-native ransomware:
 > 📌 This is not an exhaustive list. Root causes vary by environment and threat actor. Use evidence from Part 2 to identify the specific initial access vector for your incident.
 
 Use evidence collected in Part 2 to trace:
+
 1. Initial access vector (how did the threat actor get credentials?)
 2. Privilege escalation path (how did they get destructive permissions?)
 3. Full scope of destructive actions (what was encrypted/deleted?)
@@ -508,6 +512,7 @@ Use evidence collected in Part 2 to trace:
    > 📌 **This list is not exhaustive.** Threat actors employ many persistence techniques beyond those listed here. For a comprehensive reference of persistence mechanisms observed in AWS environments, see the [Threat Technique Catalog for AWS](https://aws-samples.github.io/threat-technique-catalog-for-aws/).
 
 2. **Rotate all credentials in affected accounts**
+
    ```bash
    # Generate new access keys for legitimate users (after deleting compromised ones)
    aws iam create-access-key --user-name legitimate-user
@@ -520,6 +525,7 @@ Use evidence collected in Part 2 to trace:
    - Confirm all legitimate KMS keys are still enabled and accessible
    - Verify key policies have not been modified to grant threat actor access
    - If threat actor scheduled key deletion, cancel it immediately:
+
    ```bash
    aws kms cancel-key-deletion --key-id arn:aws:kms:us-east-1:123456789012:key/KEY_ID
    aws kms enable-key --key-id arn:aws:kms:us-east-1:123456789012:key/KEY_ID
@@ -536,7 +542,7 @@ Use evidence collected in Part 2 to trace:
 
 > `[IR Lead]` provides technical assessment of backup integrity. Payment decisions are outside the scope of this playbook — consult your organization's Legal counsel and cyber insurance provider.
 
-```
+```text
 Can we recover from backups?
 │
 ├── YES — Backups confirmed intact (Vault Lock / Object Lock / cross-account copies)
@@ -802,6 +808,7 @@ For detailed Athena queries, GuardDuty CLI commands, and CloudTrail investigatio
 📁 [`resources/athena-queries-ransomware.sql`](resources/athena-queries-ransomware.sql)
 
 These queries cover:
+
 - KMS key creation and encryption operations by a suspected principal
 - Bulk deletion activity across S3, EBS, RDS, and AWS Backup (with anomaly detection)
 - Snapshot operations — deletion, cross-account sharing, copying
@@ -858,7 +865,7 @@ Ransomware incidents trigger notification obligations under most regulatory fram
 | **CISA Reporting (CIRCIA)** | Covered entity experiences substantial cyber incident | 72 hours (when final rule effective) | Ransomware payment: 24 hours |
 
 > ⚠️ The clock starts at **awareness**, not confirmation. When in doubt, assume notification is required and consult Legal immediately. For ransomware, the availability impact alone (inability to access data) is sufficient to trigger most frameworks — you do not need to prove exfiltration.
-
+>
 > ⚠️ **Ransom payments** have additional reporting requirements. CISA requires reporting within 24 hours. OFAC sanctions screening is mandatory before any payment. Consult Legal before any payment decision.
 
 ---
@@ -892,6 +899,7 @@ Ransomware incidents trigger notification obligations under most regulatory fram
 When GuardDuty detects malware on an EC2 instance, automatically create EBS snapshots of all attached volumes to preserve the pre-encryption state.
 
 **EventBridge Rule Pattern:**
+
 ```json
 {
   "source": ["aws.guardduty"],

--- a/playbooks/resources/athena-queries-credential-compromise.sql
+++ b/playbooks/resources/athena-queries-credential-compromise.sql
@@ -1,0 +1,93 @@
+-- =============================================================================
+-- Athena Queries: IAM Credential Compromise Investigation
+-- Companion resource for IRP-CredCompromise.md
+-- =============================================================================
+-- Prerequisites:
+--   - CloudTrail logs delivered to S3 and queryable via Athena
+--   - Replace placeholder values: AKIAIOSFODNN7EXAMPLE, START_TIME, END_TIME
+--   - Adjust table name (cloudtrail_logs) to match your Athena table
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. All API calls made by a specific access key in a time window
+-- Purpose: Establish the full scope of activity for the credential under review
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, awsRegion, sourceIPAddress, userAgent,
+       requestParameters, responseElements, errorCode
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Unique source IPs and user agents for a credential
+-- Purpose: Distinguish legitimate usage from unauthorized usage by comparing
+--          known IPs (corporate egress, VPN) to unfamiliar ones
+-- ---------------------------------------------------------------------------
+SELECT sourceIPAddress, userAgent, COUNT(*) as call_count,
+       MIN(eventTime) as first_seen, MAX(eventTime) as last_seen
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY sourceIPAddress, userAgent
+ORDER BY first_seen ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Persistence mechanisms created by the principal under investigation
+-- Purpose: Identify if new access paths (users, roles, keys, functions) were
+--          created that would survive credential deactivation
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, sourceIPAddress, requestParameters, responseElements
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND eventName IN ('CreateUser', 'CreateRole', 'CreateAccessKey',
+                    'CreateLoginProfile', 'AttachUserPolicy', 'AttachRolePolicy',
+                    'PutUserPolicy', 'PutRolePolicy', 'UpdateAssumeRolePolicy',
+                    'CreateFunction', 'UpdateFunctionCode', 'AddPermission',
+                    'CreateEventSourceMapping', 'PutBucketPolicy',
+                    'CreateTrail', 'StopLogging', 'DeleteTrail')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 4. Data access events (S3, DynamoDB, Secrets Manager, SSM)
+-- Purpose: Determine if sensitive data was accessed by the credential
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, eventSource, requestParameters, sourceIPAddress
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND eventSource IN ('s3.amazonaws.com', 'dynamodb.amazonaws.com',
+                      'secretsmanager.amazonaws.com', 'ssm.amazonaws.com')
+  AND eventName IN ('GetObject', 'GetItem', 'BatchGetItem', 'GetSecretValue',
+                    'GetParameter', 'GetParameters')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. Cross-account role assumptions from the credential
+-- Purpose: Identify lateral movement to other AWS accounts
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, requestParameters, responseElements,
+       sourceIPAddress, recipientAccountId
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND eventName = 'AssumeRole'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 6. Error events (failed API calls indicate reconnaissance or permission testing)
+-- Purpose: Understand what the credential attempted but was denied
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, errorCode, errorMessage, sourceIPAddress
+FROM cloudtrail_logs
+WHERE userIdentity.accessKeyId = 'AKIAIOSFODNN7EXAMPLE'
+  AND errorCode IS NOT NULL
+  AND errorCode != ''
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;

--- a/playbooks/resources/athena-queries-data-access.sql
+++ b/playbooks/resources/athena-queries-data-access.sql
@@ -1,0 +1,207 @@
+-- =============================================================================
+-- Athena Queries: Unauthorized Data Access Investigation
+-- Companion resource for IRP-DataAccess.md
+-- =============================================================================
+-- Prerequisites:
+--   - CloudTrail logs delivered to S3 and queryable via Athena
+--   - S3 data events enabled in CloudTrail for sensitive buckets
+--   - Replace placeholder values: BUCKET_NAME, TABLE_NAME, SUSPECT_PRINCIPAL,
+--     START_TIME, END_TIME, ACCOUNT_ID
+--   - Adjust table name (cloudtrail_logs) to match your Athena table
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. All S3 data access events for a specific bucket in a time window
+-- Purpose: Establish the complete picture of who accessed the bucket and how
+--          during the incident window. This is typically the first query to run.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, sourceIPAddress, userIdentity.arn,
+       userAgent, requestParameters, responseElements, errorCode
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND requestParameters LIKE '%BUCKET_NAME%'
+  AND eventName IN ('GetObject', 'HeadObject', 'ListObjects', 'ListObjectsV2',
+                    'SelectObjectContent', 'CopyObject')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Top accessors of a bucket (identify anomalous principals)
+-- Purpose: Quickly identify who is reading from the bucket and how much data
+--          they transferred. Compare against known legitimate access patterns
+--          to spot unauthorized principals.
+-- ---------------------------------------------------------------------------
+SELECT userIdentity.arn, sourceIPAddress, COUNT(*) as access_count,
+       SUM(CAST(additionalEventData.bytesTransferredOut AS BIGINT)) as bytes_out
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND requestParameters LIKE '%BUCKET_NAME%'
+  AND eventName = 'GetObject'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY userIdentity.arn, sourceIPAddress
+ORDER BY access_count DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Detect bulk data access (high-volume reads in short time)
+-- Purpose: Identify principals performing bulk reads that exceed normal
+--          operational patterns — a key indicator of data exfiltration.
+--          Adjust the HAVING threshold based on normal bucket access volume.
+-- ---------------------------------------------------------------------------
+SELECT DATE_TRUNC('hour', from_iso8601_timestamp(eventTime)) as hour_bucket,
+       userIdentity.arn, COUNT(*) as read_count
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters LIKE '%BUCKET_NAME%'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY DATE_TRUNC('hour', from_iso8601_timestamp(eventTime)), userIdentity.arn
+HAVING COUNT(*) > 100
+ORDER BY hour_bucket ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 4. DynamoDB data access (Scan operations are a red flag for exfiltration)
+-- Purpose: Identify data reads from DynamoDB tables. Scan operations reading
+--          entire tables are particularly suspicious — legitimate applications
+--          typically use Query or GetItem with specific key conditions.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, sourceIPAddress, userIdentity.arn,
+       requestParameters
+FROM cloudtrail_logs
+WHERE eventSource = 'dynamodb.amazonaws.com'
+  AND eventName IN ('Scan', 'Query', 'BatchGetItem', 'GetItem')
+  AND requestParameters LIKE '%TABLE_NAME%'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. Secrets Manager / Parameter Store access
+-- Purpose: Determine if the threat actor accessed stored secrets or
+--          configuration parameters. Accessed secrets should be rotated
+--          immediately during eradication.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, sourceIPAddress, userIdentity.arn,
+       requestParameters
+FROM cloudtrail_logs
+WHERE eventSource IN ('secretsmanager.amazonaws.com', 'ssm.amazonaws.com')
+  AND eventName IN ('GetSecretValue', 'GetParameter', 'GetParameters',
+                    'GetParametersByPath')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 6. All GetObject calls for a specific bucket, grouped by principal
+-- Purpose: Provide a summary view showing which principals accessed the
+--          bucket, how many objects they read, and their access window.
+--          Useful for reporting and impact assessment.
+-- ---------------------------------------------------------------------------
+SELECT userIdentity.arn, sourceIPAddress, COUNT(*) as read_count,
+       MIN(eventTime) as first_access, MAX(eventTime) as last_access
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters LIKE '%BUCKET_NAME%'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY userIdentity.arn, sourceIPAddress
+ORDER BY read_count DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 7. Detect data staging (copies to other buckets or accounts)
+-- Purpose: Identify if the threat actor copied data to a location they
+--          control — a staging step before exfiltration. Check for copies
+--          to unfamiliar buckets or cross-account destinations.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, userIdentity.arn, sourceIPAddress,
+       json_extract_scalar(requestParameters, '$.bucketName') as source_bucket,
+       json_extract_scalar(requestParameters, '$.x-amz-copy-source') as copy_source
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('CopyObject', 'PutObject', 'UploadPart')
+  AND userIdentity.arn = 'SUSPECT_PRINCIPAL'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 8. Identify specific objects accessed (what data was read)
+-- Purpose: Determine exactly which objects the threat actor accessed.
+--          Essential for data impact assessment and regulatory notification
+--          decisions — you need to know what data was exposed.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, json_extract_scalar(requestParameters, '$.key') as object_key,
+       sourceIPAddress, userIdentity.arn
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters LIKE '%BUCKET_NAME%'
+  AND userIdentity.arn = 'SUSPECT_PRINCIPAL'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 9. Detect bucket policy or ACL changes (threat actor granting access)
+-- Purpose: Identify if the threat actor modified the bucket's access controls
+--          to grant themselves (or others) persistent access. Policy changes
+--          are a form of persistence that survives credential rotation.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn, sourceIPAddress,
+       requestParameters
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('PutBucketPolicy', 'DeleteBucketPolicy', 'PutBucketAcl',
+                    'PutObjectAcl', 'PutBucketPublicAccessBlock',
+                    'DeleteBucketPublicAccessBlock')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 10. S3 server access log analysis
+-- Purpose: S3 server access logs capture requests that CloudTrail data events
+--          may miss (e.g., anonymous access, presigned URL usage). Query these
+--          if you suspect access via presigned URLs or public exposure.
+-- Note: Requires S3 access logs stored in an Athena-queryable format.
+-- ---------------------------------------------------------------------------
+SELECT request_datetime, remote_ip, requester, operation, key,
+       http_status, bytes_sent, total_time
+FROM s3_access_logs
+WHERE bucket = 'AFFECTED_BUCKET'
+  AND operation = 'REST.GET.OBJECT'
+  AND request_datetime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY request_datetime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 11. Check if the threat actor accessed other buckets
+-- Purpose: Determine if the data access was limited to one bucket or if
+--          the principal accessed additional data stores. Important for
+--          scoping the full impact.
+-- ---------------------------------------------------------------------------
+SELECT DISTINCT json_extract_scalar(requestParameters, '$.bucketName') as bucket_accessed
+FROM cloudtrail_logs
+WHERE userIdentity.arn = 'SUSPECT_PRINCIPAL'
+  AND eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME';
+
+
+-- ---------------------------------------------------------------------------
+-- 12. Check for data copies to threat-actor-controlled locations
+-- Purpose: Identify if the threat actor created snapshots, copies, or
+--          exports of data to locations outside your control. This confirms
+--          exfiltration vs. in-place access.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, requestParameters
+FROM cloudtrail_logs
+WHERE userIdentity.arn = 'SUSPECT_PRINCIPAL'
+  AND eventName IN ('CopyObject', 'PutObject', 'CreateSnapshot',
+                    'CopySnapshot', 'ShareSnapshot')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;

--- a/playbooks/resources/athena-queries-dos.sql
+++ b/playbooks/resources/athena-queries-dos.sql
@@ -1,0 +1,228 @@
+-- =============================================================================
+-- Athena Queries: DoS / DDoS Investigation
+-- Companion resource for IRP-DoS.md
+-- =============================================================================
+-- Prerequisites:
+--   - CloudFront access logs delivered to S3 and queryable via Athena
+--   - WAF logs delivered to S3 and queryable via Athena
+--   - VPC Flow Logs delivered to S3 and queryable via Athena
+--   - Replace placeholder values: date ranges, epoch timestamps, target IPs
+--   - Adjust table names to match your Athena tables
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 1: CloudFront Access Log Queries
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1.1 Top source IPs by request volume during attack window
+-- Purpose: Identify the highest-volume sources contributing to the attack.
+--   Helps prioritize IP blocklist entries and understand attack distribution.
+-- ---------------------------------------------------------------------------
+SELECT "c-ip" AS source_ip,
+       COUNT(*) AS request_count,
+       COUNT(DISTINCT "cs-uri-stem") AS unique_paths,
+       AVG("time-taken") AS avg_response_time_ms
+FROM cloudfront_logs
+WHERE date BETWEEN DATE '2026-01-01' AND DATE '2026-01-01'
+  AND time BETWEEN '14:00:00' AND '15:00:00'
+GROUP BY "c-ip"
+HAVING COUNT(*) > 1000
+ORDER BY request_count DESC
+LIMIT 50;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.2 Application-layer attack pattern detection (single URI targeted)
+-- Purpose: Identify which endpoints are being targeted and whether the attack
+--   is focused on expensive/slow endpoints (API abuse pattern) vs. broad flood.
+-- ---------------------------------------------------------------------------
+SELECT "cs-uri-stem" AS target_path,
+       "cs-method" AS http_method,
+       COUNT(*) AS request_count,
+       COUNT(DISTINCT "c-ip") AS unique_sources,
+       SUM(CASE WHEN "sc-status" >= 500 THEN 1 ELSE 0 END) AS error_5xx_count
+FROM cloudfront_logs
+WHERE date = DATE '2026-01-01'
+  AND time BETWEEN '14:00:00' AND '15:00:00'
+GROUP BY "cs-uri-stem", "cs-method"
+ORDER BY request_count DESC
+LIMIT 20;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.3 Top source IPs with 5xx correlation and response time
+-- Purpose: Extended version of 1.1 with percentile response time and 5xx
+--   correlation. Useful for identifying sources that are actually causing
+--   backend saturation vs. those just adding volume.
+-- ---------------------------------------------------------------------------
+SELECT "c-ip" AS source_ip,
+       COUNT(*) AS total_requests,
+       COUNT(DISTINCT "cs-uri-stem") AS unique_uris,
+       SUM(CASE WHEN "sc-status" >= 500 THEN 1 ELSE 0 END) AS requests_causing_5xx,
+       APPROX_PERCENTILE("time-taken", 0.95) AS p95_response_ms
+FROM cloudfront_logs
+WHERE date = DATE '2026-01-01'
+  AND time BETWEEN '14:00:00' AND '16:00:00'
+GROUP BY "c-ip"
+HAVING COUNT(*) > 500
+ORDER BY total_requests DESC
+LIMIT 100;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.4 User-Agent distribution during attack window
+-- Purpose: Identify attack tools or botnets by User-Agent fingerprint.
+--   Legitimate traffic typically has diverse user agents; botnets often share
+--   a common (or absent) user agent string.
+-- ---------------------------------------------------------------------------
+SELECT "cs(User-Agent)" AS user_agent,
+       COUNT(*) AS request_count,
+       COUNT(DISTINCT "c-ip") AS unique_ips
+FROM cloudfront_logs
+WHERE date = DATE '2026-01-01'
+  AND time BETWEEN '14:00:00' AND '16:00:00'
+GROUP BY "cs(User-Agent)"
+ORDER BY request_count DESC
+LIMIT 20;
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 2: WAF Log Queries
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 2.1 Blocked and counted requests during attack
+-- Purpose: Understand which WAF rules are triggering, which IPs are being
+--   blocked, and which URIs are targeted. Helps assess rule effectiveness
+--   and identify gaps where attack traffic is getting through.
+-- ---------------------------------------------------------------------------
+SELECT httprequest.clientip AS source_ip,
+       httprequest.uri AS request_uri,
+       httprequest.httpmethod AS method,
+       action,
+       terminatingruleid AS rule_triggered,
+       COUNT(*) AS request_count
+FROM waf_logs
+WHERE timestamp BETWEEN 1716904800000 AND 1716908400000
+GROUP BY httprequest.clientip, httprequest.uri,
+         httprequest.httpmethod, action, terminatingruleid
+ORDER BY request_count DESC
+LIMIT 100;
+
+
+-- ---------------------------------------------------------------------------
+-- 2.2 Rate-based rule effectiveness analysis
+-- Purpose: Evaluate how well rate-based rules performed during the attack.
+--   Shows whether rules triggered appropriately and blocked attack traffic,
+--   or if thresholds need adjustment.
+-- ---------------------------------------------------------------------------
+SELECT from_unixtime(timestamp/1000) AS event_time,
+       action,
+       terminatingruleid,
+       httprequest.clientip AS source_ip,
+       httprequest.country AS country,
+       httprequest.uri AS uri,
+       COUNT(*) AS request_count
+FROM waf_logs
+WHERE timestamp BETWEEN 1716904800000 AND 1716915600000
+GROUP BY from_unixtime(timestamp/1000), action, terminatingruleid,
+         httprequest.clientip, httprequest.country, httprequest.uri
+ORDER BY request_count DESC
+LIMIT 200;
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 3: VPC Flow Log Queries
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 3.1 Volumetric attack sources (high packet/byte count)
+-- Purpose: Identify Layer 3/4 volumetric attack sources by total packet and
+--   byte volume. Useful for NACLs and understanding attack magnitude when
+--   traffic bypasses CloudFront (direct-to-origin attacks).
+-- ---------------------------------------------------------------------------
+SELECT srcaddr, dstaddr, dstport, protocol,
+       SUM(packets) AS total_packets,
+       SUM(bytes) AS total_bytes,
+       COUNT(*) AS flow_records
+FROM vpc_flow_logs
+WHERE start >= 1716904800  -- epoch timestamp for attack window start
+  AND "end" <= 1716908400  -- epoch timestamp for attack window end
+  AND action = 'ACCEPT'
+GROUP BY srcaddr, dstaddr, dstport, protocol
+HAVING SUM(packets) > 100000
+ORDER BY total_packets DESC
+LIMIT 50;
+
+
+-- ---------------------------------------------------------------------------
+-- 3.2 Attack patterns by protocol and port
+-- Purpose: Identify which protocols and ports are targeted to characterize
+--   the attack type (UDP flood, SYN flood, DNS amplification, etc.) and
+--   estimate total attack bandwidth.
+-- ---------------------------------------------------------------------------
+SELECT dstport, protocol,
+       COUNT(DISTINCT srcaddr) AS unique_sources,
+       SUM(packets) AS total_packets,
+       SUM(bytes) / 1073741824.0 AS total_gb,
+       SUM(bytes) / NULLIF(MAX("end") - MIN(start), 0) AS bytes_per_second
+FROM vpc_flow_logs
+WHERE start >= 1716904800
+  AND "end" <= 1716915600
+  AND dstaddr = '10.0.1.100'  -- replace with target IP
+  AND action = 'ACCEPT'
+GROUP BY dstport, protocol
+ORDER BY total_packets DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 4: CloudWatch Logs Insights (ALB Request Logs)
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 4.1 Request patterns causing backend saturation
+-- Purpose: Identify which client IPs and request URLs are generating 5xx
+--   errors or excessive processing time. Helps focus WAF rules on the
+--   specific request patterns causing application impact.
+-- Note: Run this in CloudWatch Logs Insights, not Athena.
+-- ---------------------------------------------------------------------------
+-- fields @timestamp, elb_status_code, target_status_code,
+--        request_url, client_ip, target_processing_time
+-- | filter elb_status_code >= 500 OR target_processing_time > 5
+-- | stats count() as error_count by request_url, client_ip
+-- | sort error_count desc
+-- | limit 50
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 5: GuardDuty Finding Queries (CLI reference)
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 5.1 List DoS-related GuardDuty findings
+-- Purpose: Identify if GuardDuty has detected your infrastructure
+--   participating in (outbound) DoS activity, which would indicate
+--   resource compromise rather than being a target.
+-- Note: Run via AWS CLI, not Athena.
+-- ---------------------------------------------------------------------------
+-- aws guardduty list-findings \
+--   --detector-id DETECTOR_ID \
+--   --finding-criteria '{
+--     "Criterion": {
+--       "type": {
+--         "Eq": [
+--           "Backdoor:EC2/DenialOfService.Tcp",
+--           "Backdoor:EC2/DenialOfService.Udp",
+--           "Backdoor:EC2/DenialOfService.Dns",
+--           "Impact:EC2/PortSweep"
+--         ]
+--       }
+--     }
+--   }' \
+--   --region us-east-1
+--
+-- aws guardduty get-findings \
+--   --detector-id DETECTOR_ID \
+--   --finding-ids FINDING_ID_1 FINDING_ID_2

--- a/playbooks/resources/athena-queries-personal-data-breach.sql
+++ b/playbooks/resources/athena-queries-personal-data-breach.sql
@@ -1,0 +1,264 @@
+-- =============================================================================
+-- Athena Queries: Personal Data Breach Investigation
+-- Companion resource for IRP-PersonalDataBreach.md
+-- =============================================================================
+-- Prerequisites:
+--   - CloudTrail logs delivered to S3 and queryable via Athena
+--   - CloudTrail S3 data events enabled on buckets containing personal data
+--   - Replace placeholder values: customer-pii-bucket, START_TIME, END_TIME,
+--     account IDs, and role ARNs with your actual values
+--   - Adjust table name (cloudtrail_logs) to match your Athena table
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 1: Evidence Collection Queries
+-- Purpose: Gather forensic evidence for regulatory investigation
+-- Context: Run these early in the incident to preserve evidence before any
+--          remediation actions that might alter the audit trail
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1.1 All S3 data access events on buckets tagged as containing personal data
+-- Purpose: Broad capture of all access events on PII-classified buckets during
+--          the incident window. Use this as your baseline evidence set.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn AS accessor,
+       userIdentity.accountId AS accessor_account,
+       requestParameters.bucketName AS bucket,
+       requestParameters.key AS object_key,
+       sourceIPAddress, userAgent,
+       additionalEventData.bytesTransferredOut AS bytes_transferred,
+       errorCode
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('GetObject', 'SelectObjectContent', 'CopyObject',
+                    'HeadObject', 'ListObjects', 'ListObjectsV2')
+  AND requestParameters.bucketName IN ('customer-pii-bucket', 'hr-records-bucket',
+                                        'health-data-bucket')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.2 Identify cross-account access to personal data buckets
+-- Purpose: Detect access from accounts outside the data-owning organization.
+--          Cross-account access is a strong indicator of unauthorized disclosure.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, userIdentity.arn AS accessor,
+       userIdentity.accountId AS accessor_account,
+       requestParameters.bucketName AS bucket,
+       requestParameters.key AS object_key,
+       sourceIPAddress,
+       additionalEventData.bytesTransferredOut AS bytes_out
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND userIdentity.accountId != '123456789012'  -- Replace with bucket owner account
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.3 Estimate number of unique records/individuals affected
+-- Purpose: Provide the Privacy Officer with a defensible estimate of affected
+--          individual count for regulatory notification. Based on object count
+--          and known record density per file type.
+-- ---------------------------------------------------------------------------
+SELECT requestParameters.bucketName AS bucket,
+       COUNT(DISTINCT requestParameters.key) AS unique_objects_accessed,
+       COUNT(*) AS total_access_events,
+       SUM(CAST(additionalEventData.bytesTransferredOut AS BIGINT)) AS total_bytes,
+       MIN(eventTime) AS first_access,
+       MAX(eventTime) AS last_access
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND userIdentity.arn = 'arn:aws:iam::999888777666:role/SuspiciousRole'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+GROUP BY requestParameters.bucketName;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.4 Detect bulk download patterns (potential exfiltration)
+-- Purpose: Flag any principal downloading more than 100 objects in a 1-hour
+--          window. Bulk access to PII-classified buckets is a strong indicator
+--          of data exfiltration requiring regulatory notification.
+-- ---------------------------------------------------------------------------
+SELECT userIdentity.arn AS accessor,
+       DATE_TRUNC('hour', from_iso8601_timestamp(eventTime)) AS hour_window,
+       COUNT(*) AS objects_accessed,
+       SUM(CAST(additionalEventData.bytesTransferredOut AS BIGINT)) AS total_bytes
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+GROUP BY userIdentity.arn, DATE_TRUNC('hour', from_iso8601_timestamp(eventTime))
+HAVING COUNT(*) > 100
+ORDER BY objects_accessed DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 1.5 Macie finding correlation with CloudTrail access
+-- Purpose: Correlate Macie-identified PII objects with CloudTrail access events
+--          to determine whether objects *confirmed to contain personal data* were
+--          actually accessed during the incident window.
+-- Usage:  Export Macie findings first to identify object keys, then insert them
+--          into the IN clause below.
+-- ---------------------------------------------------------------------------
+SELECT ct.eventTime, ct.userIdentity.arn AS accessor,
+       ct.requestParameters.key AS object_key,
+       ct.sourceIPAddress,
+       ct.additionalEventData.bytesTransferredOut AS bytes_out,
+       ct.userAgent
+FROM cloudtrail_logs ct
+WHERE ct.eventSource = 's3.amazonaws.com'
+  AND ct.eventName = 'GetObject'
+  AND ct.requestParameters.bucketName = 'customer-pii-bucket'
+  AND ct.requestParameters.key IN (
+    -- Insert object keys from Macie findings that contain PII
+    'data/customers/export-20260501.csv',
+    'data/customers/full-extract.json.gz',
+    'backups/db-snapshot-customers-20260515.sql'
+  )
+  AND ct.eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND ct.errorCode IS NULL
+ORDER BY ct.eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 2: Scope Determination Queries
+-- Purpose: Help the Privacy Officer determine the full scope of the breach
+--          for notification obligation assessment
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 2.1 All access by the suspect principal on the affected bucket
+-- Purpose: Complete picture of what the unauthorized accessor touched.
+--          Feed results to Privacy Officer for notification scope.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, userIdentity.arn AS accessor_arn,
+       userIdentity.accountId AS accessor_account,
+       requestParameters.bucketName AS bucket,
+       requestParameters.key AS object_key,
+       sourceIPAddress, userAgent,
+       additionalEventData.bytesTransferredOut AS bytes_out
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('GetObject', 'SelectObjectContent', 'HeadObject')
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2.2 Data volume determination by suspect principal
+-- Purpose: Quantify total data accessed for regulatory notification content.
+--          Regulators require "approximate number of records" in notifications.
+-- ---------------------------------------------------------------------------
+SELECT requestParameters.bucketName AS bucket,
+       COUNT(DISTINCT requestParameters.key) AS unique_objects_accessed,
+       COUNT(*) AS total_get_requests,
+       SUM(CAST(additionalEventData.bytesTransferredOut AS BIGINT)) AS total_bytes_out
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND userIdentity.arn = 'arn:aws:iam::999888777666:role/SuspiciousRole'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+GROUP BY requestParameters.bucketName;
+
+
+-- ---------------------------------------------------------------------------
+-- 2.3 Exfiltration indicators — access from non-AWS IP addresses
+-- Purpose: Determine if data left the AWS environment. This is the critical
+--          question for notification obligations. Data accessed from non-AWS
+--          IPs is a strong indicator of exfiltration.
+-- Note:   This is a heuristic — some AWS services use public IPs. Cross-
+--          reference with known corporate/VPN egress ranges.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, sourceIPAddress, userIdentity.arn,
+       requestParameters.key, additionalEventData.bytesTransferredOut
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'GetObject'
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+  AND errorCode IS NULL
+  AND sourceIPAddress NOT LIKE '10.%'
+  AND sourceIPAddress NOT LIKE '172.%'
+  AND sourceIPAddress NOT LIKE '192.168.%'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2.4 Configuration changes to the affected bucket during incident window
+-- Purpose: Detect if the threat actor modified bucket policies, ACLs, or
+--          replication rules to facilitate exfiltration or cover tracks.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn AS actor,
+       sourceIPAddress, requestParameters, responseElements
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('PutBucketPolicy', 'DeleteBucketPolicy',
+                    'PutBucketAcl', 'PutBucketReplication',
+                    'PutBucketPublicAccessBlock', 'DeleteBucketPublicAccessBlock')
+  AND requestParameters.bucketName = 'customer-pii-bucket'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- SECTION 3: GuardDuty and Macie Evidence Export (CLI)
+-- Purpose: Export findings as evidence for regulatory investigation
+-- ---------------------------------------------------------------------------
+
+-- Note: These are AWS CLI commands, not SQL. Run in your terminal.
+--
+-- List S3-related exfiltration findings:
+-- aws guardduty list-findings \
+--   --detector-id DETECTOR_ID \
+--   --finding-criteria '{
+--     "Criterion": {
+--       "type": {
+--         "Eq": ["Exfiltration:S3/MaliciousIPCaller",
+--                "Exfiltration:S3/AnomalousBehavior",
+--                "UnauthorizedAccess:S3/TorIPCaller"]
+--       },
+--       "severity": {"Gte": 7}
+--     }
+--   }' \
+--   --region us-east-1
+--
+-- Get full finding details for regulatory evidence:
+-- aws guardduty get-findings \
+--   --detector-id DETECTOR_ID \
+--   --finding-ids FINDING_ID_1 FINDING_ID_2 \
+--   --region us-east-1 | tee guardduty-findings-export.json
+--
+-- List Macie findings for affected bucket:
+-- aws macie2 list-findings \
+--   --finding-criteria '{
+--     "criterion": {
+--       "resourcesAffected.s3Bucket.name": {
+--         "eq": ["customer-pii-bucket"]
+--       },
+--       "category": {
+--         "eq": ["CLASSIFICATION"]
+--       }
+--     }
+--   }' \
+--   --region us-east-1
+--
+-- Get detailed Macie finding information:
+-- aws macie2 get-findings \
+--   --finding-ids FINDING_ID_1 FINDING_ID_2 \
+--   --region us-east-1 | tee macie-findings-export.json

--- a/playbooks/resources/athena-queries-ransomware.sql
+++ b/playbooks/resources/athena-queries-ransomware.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- Athena Queries: Ransomware Investigation
+-- Companion resource for IRP-Ransomware.md
+-- =============================================================================
+-- Prerequisites:
+--   - CloudTrail logs delivered to S3 and queryable via Athena
+--   - Replace placeholder values: SUSPECTED_PRINCIPAL, START_TIME, END_TIME
+--   - Adjust table name (cloudtrail_logs) to match your Athena table
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. KMS key creation and encryption operations by a suspect principal
+-- Purpose: Detect threat actor creating attacker-controlled KMS keys and using
+--   them to encrypt resources. This is the primary indicator for EBS volume
+--   encryption ransomware (Pattern 1 in Appendix E).
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn, awsRegion,
+       requestParameters, responseElements, sourceIPAddress
+FROM cloudtrail_logs
+WHERE userIdentity.arn LIKE '%SUSPECTED_PRINCIPAL%'
+  AND eventSource = 'kms.amazonaws.com'
+  AND eventName IN ('CreateKey', 'CreateGrant', 'Encrypt', 'ReEncryptFrom',
+                    'ReEncryptTo', 'GenerateDataKey', 'GenerateDataKeyWithoutPlaintext',
+                    'ScheduleKeyDeletion', 'DisableKey', 'PutKeyPolicy')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. Bulk deletion activity across S3, EBS, and RDS
+-- Purpose: Identify destructive actions across multiple services. Ransomware
+--   actors typically delete snapshots, suspend versioning, and destroy backups
+--   to eliminate recovery options before demanding payment.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventSource, eventName, userIdentity.arn,
+       requestParameters, sourceIPAddress, awsRegion
+FROM cloudtrail_logs
+WHERE eventName IN ('DeleteObject', 'DeleteObjects', 'DeleteSnapshot',
+                    'DeleteDBSnapshot', 'DeleteDBClusterSnapshot',
+                    'DeleteRecoveryPoint', 'DeleteBackupVault',
+                    'PutBucketVersioning', 'DeleteBucketPolicy')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Snapshot operations (deleted, copied, or shared)
+-- Purpose: Track snapshot manipulation — threat actors may delete snapshots
+--   to prevent recovery, or share/copy them to exfiltrate data before
+--   encrypting (double extortion).
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn, awsRegion,
+       requestParameters, responseElements, errorCode
+FROM cloudtrail_logs
+WHERE eventSource = 'ec2.amazonaws.com'
+  AND eventName IN ('DeleteSnapshot', 'ModifySnapshotAttribute',
+                    'CopySnapshot', 'CreateSnapshot', 'CreateSnapshots')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 4. S3 versioning suspension and Object Lock modifications
+-- Purpose: Detect threat actor disabling protective controls before deletion.
+--   Versioning suspension followed by bulk deletion is a signature pattern
+--   for S3 ransomware (Pattern 2 in Appendix E).
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn,
+       requestParameters, sourceIPAddress
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName IN ('PutBucketVersioning', 'PutObjectLockConfiguration',
+                    'PutBucketLifecycleConfiguration', 'DeleteBucketPolicy',
+                    'PutBucketPolicy')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. All KMS operations in a time window
+-- Purpose: Broad KMS activity sweep to detect threat actor key creation and
+--   usage patterns. Useful when the specific principal is not yet identified.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn, awsRegion,
+       requestParameters, responseElements, sourceIPAddress, errorCode
+FROM cloudtrail_logs
+WHERE eventSource = 'kms.amazonaws.com'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 6. High-volume deletion activity (ransomware indicator)
+-- Purpose: Identify principals performing bulk delete operations. Any principal
+--   with >10 delete calls in the incident window warrants investigation.
+-- ---------------------------------------------------------------------------
+SELECT eventSource, eventName, userIdentity.arn,
+       COUNT(*) as call_count, MIN(eventTime) as first_seen, MAX(eventTime) as last_seen
+FROM cloudtrail_logs
+WHERE eventName LIKE 'Delete%'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+GROUP BY eventSource, eventName, userIdentity.arn
+HAVING call_count > 10
+ORDER BY call_count DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 7. S3 bucket versioning changes
+-- Purpose: Detect versioning being disabled — a precursor to bulk deletion
+--   in S3 ransomware attacks. Versioning suspension makes deleted objects
+--   unrecoverable.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, userIdentity.arn, requestParameters, sourceIPAddress
+FROM cloudtrail_logs
+WHERE eventSource = 's3.amazonaws.com'
+  AND eventName = 'PutBucketVersioning'
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 8. Cross-account snapshot sharing (data exfiltration via snapshots)
+-- Purpose: Detect threat actor sharing snapshots to external accounts before
+--   deleting them — the double-extortion pattern where data is exfiltrated
+--   via snapshot sharing before the encryption/deletion phase.
+-- ---------------------------------------------------------------------------
+SELECT eventTime, eventName, userIdentity.arn, requestParameters, responseElements
+FROM cloudtrail_logs
+WHERE eventName IN ('ModifySnapshotAttribute', 'ModifyDBSnapshotAttribute',
+                    'ModifyDBClusterSnapshotAttribute')
+  AND eventTime BETWEEN 'START_TIME' AND 'END_TIME'
+ORDER BY eventTime ASC;


### PR DESCRIPTION
Brings all 5 existing incident response playbooks up to the template structure established in PR #1, aligns with NIST SP 800-61r3 and the CSF 2.0 Community Profile, and adds practical improvements based on real-world incident response experience.

### What changed
All 5 playbooks refreshed:

- IRP-CredCompromise.md
- IRP-DataAccess.md
- IRP-DoS.md
- IRP-PersonalDataBreach.md
- IRP-Ransomware.md

5 companion resource files created:

- athena-queries-credential-compromise.sql
- athena-queries-data-access.sql
- athena-queries-dos.sql
- athena-queries-personal-data-breach.sql
- athena-queries-ransomware.sql

### Key improvements

- Context paragraphs added to every section — explains why before what
- Well-Architected Framework references (SEC10-BP01, BP04, BP05, BP06) linked throughout preparation sections
- AWS Security Incident Response service workflow updated to match current console experience (Create Case → Resolve with AWS → Active Security Incident / Investigations and Inquiries)
- AWS engagement expanded to P1–P3 — CIRT can help determine if activity is malicious, not just assist after confirmation
- Eradication separated from Recovery in CredCompromise and DataAccess (iterative containment-eradication loop documented)
- Athena queries moved to companion SQL files — reduces playbook bulk while keeping queries versioned and copy-pasteable
- Credential containment rewritten to cover all credential types (access keys, console passwords, STS tokens) with different approaches for each
- "Without Macie" alternative added to PersonalDataBreach for customers who don't have Macie enabled prior to an incident
- Ransom payment section refocused — technical recovery is our lane, payment decisions directed to Legal counsel and cyber insurance
- Threat Technique Catalog for AWS referenced in all 5 playbooks for persistence technique awareness
- Free workshop resources replacing paid-service-dependent Game Days links
- Lifecycle policy time-bombs added to ransomware triage (S3 lifecycle, KMS deletion, RDS retention changes)
- "(Coming Soon)" on forward-reference links to playbooks in PRs 3–5

### What was tested
All internal markdown links verified
All external URLs confirmed accessible
Spelling/terminology grep across all files (zero remaining issues)
Template structure alignment validated against PLAYBOOK_TEMPLATE.md
Forward references (will resolve when PRs 3–5 merge)

These playbooks are referenced but don't exist yet:

- IRP-STSTokenAbuse (PR 3)
- IRP-IdentityCenterCompromise (PR 3)
- IRP-FederatedAccessAbuse (PR 3)
- IRP-InsiderThreat (PR 3)
- IRP-EC2Compromise (PR 4)
- IRP-S3DataExfiltration (PR 5)
- IRP-NetworkIntrusion (not yet planned)
- IRP-ResourceHijacking (not yet planned)